### PR TITLE
Release 2.9.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,9 @@ jobs:
           timeout: 1200
           no_output_timeout: 2h
 
-      - run: ./gradlew :launchdarkly-android-client-sdk:assembleDebug --console=plain -PdisablePreDex
+      - run:
+          name: Compile
+          command: ./gradlew :launchdarkly-android-client-sdk:assembleDebug --console=plain -PdisablePreDex
 
       - run:
           name: Wait for emulator to boot
@@ -73,12 +75,18 @@ jobs:
             adb logcat >> ~/artifacts/logcat.txt
 
       - run:
-          name: Run Tests
+          name: Run tests
           command: ./gradlew :launchdarkly-android-client-sdk:connectedAndroidTest --console=plain -PdisablePreDex
           no_output_timeout: 2h
 
-      - run: ./gradlew packageRelease --console=plain -PdisablePreDex
+      - run:
+          name: Validate package creation
+          command: ./gradlew packageRelease --console=plain -PdisablePreDex
 
+      - run:
+          name: Validate Javadoc
+          command: ./gradlew Javadoc
+      
       - run:
           name: Save test results
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 All notable changes to the LaunchDarkly Android SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.9.1] - 2020-01-03
+### Fixed:
+- Removed possibility of fatal `SecurityException` on Samsung devices that would be triggered when the SDK attempted to register an alarm to trigger a future poll when the application process already had 500 alarms registered. This limit is only present on Samsung's versions of Android Lollipop and later. The SDK will now catch this error if it occurs to prevent killing the host application.
+- Rarely, the client would deliver its initial "identify" event to LaunchDarkly immediately rather than waiting for the configured flush interval.
+- Fixed some malformed Javadoc comments.
+
 ## [2.9.0] - 2019-10-25
 ### Added
 - Added support for new LaunchDarkly experimentation features. See `LDClient.track(String, JsonElement, Double)` for recording numeric metrics.

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation project(path: ':launchdarkly-android-client-sdk')
     // Comment the previous line and uncomment this one to depend on the published artifact:
-    //implementation 'com.launchdarkly:launchdarkly-android-client-sdk:2.9.0'
+    //implementation 'com.launchdarkly:launchdarkly-android-client-sdk:2.9.1'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
 

--- a/launchdarkly-android-client-sdk/build.gradle
+++ b/launchdarkly-android-client-sdk/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'io.codearte.nexus-staging'
 
 allprojects {
     group = 'com.launchdarkly'
-    version = '2.9.0'
+    version = '2.9.1'
     sourceCompatibility = 1.7
     targetCompatibility = 1.7
 }

--- a/launchdarkly-android-client-sdk/build.gradle
+++ b/launchdarkly-android-client-sdk/build.gradle
@@ -40,10 +40,6 @@ android {
         execution 'ANDROID_TEST_ORCHESTRATOR'
     }
 
-    configurations {
-        javadocDeps
-    }
-
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
@@ -89,10 +85,6 @@ dependencies {
     androidTestImplementation 'org.easymock:easymock:3.6'
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:$okhttpVersion"
-
-    javadocDeps "com.google.code.gson:gson:$gsonVersion"
-    javadocDeps "com.squareup.okhttp3:okhttp:$okhttpVersion"
-    javadocDeps "com.launchdarkly:okhttp-eventsource:$eventsourceVersion"
 }
 
 repositories {
@@ -125,10 +117,15 @@ task sourcesJar(type: Jar) {
 }
 
 task javadoc(type: Javadoc) {
-    failOnError false
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    classpath += configurations.javadocDeps
+}
+
+afterEvaluate {
+// https://stackoverflow.com/questions/34571371/android-studio-javadoc-cannot-find-symbol/34572606#34572606
+    javadoc.classpath += files(android.libraryVariants.collect { variant ->
+        variant.javaCompile.classpath.files
+    })
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/android/LDClientTest.java
+++ b/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/android/LDClientTest.java
@@ -28,7 +28,6 @@ import okhttp3.mockwebserver.RecordedRequest;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
@@ -37,6 +36,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(AndroidJUnit4.class)
 public class LDClientTest {
+
+    private static final String mobileKey = "test-mobile-key";
 
     @Rule
     public final ActivityTestRule<TestActivity> activityTestRule =
@@ -191,277 +192,216 @@ public class LDClientTest {
 
     @Test
     public void testTrack() throws IOException, InterruptedException {
-        MockWebServer mockEventsServer = new MockWebServer();
-        mockEventsServer.start();
-        // Enqueue a successful empty response
-        mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
+        try (MockWebServer mockEventsServer = new MockWebServer()) {
+            mockEventsServer.start();
+            // Enqueue a successful empty response
+            mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
 
-        HttpUrl baseUrl = mockEventsServer.url("/mobile");
+            LDConfig ldConfig = baseConfigBuilder(mockEventsServer).build();
 
-        LDConfig ldConfig = new LDConfig.Builder()
-                .setMobileKey("test-mobile-sdk-key")
-                .setEventsUri(Uri.parse(baseUrl.url().toString()))
-                .build();
+            // Don't wait as we are not set offline
+            ldClient = LDClient.init(application, ldConfig, ldUser, 0);
 
-        // Don't wait as we are not set offline
-        ldClient = LDClient.init(application, ldConfig, ldUser, 0);
+            ldClient.track("test-event");
+            ldClient.blockingFlush();
 
-        ldClient.track("test-event");
-        ldClient.blockingFlush();
-
-        RecordedRequest eventPost = mockEventsServer.takeRequest();
-        assertEquals("POST", eventPost.getMethod());
-        assertEquals("/mobile", eventPost.getPath());
-        assertNotNull(eventPost.getHeader("Authorization"));
-
-        Event[] events = TestUtil.getEventDeserializerGson().fromJson(eventPost.getBody().readUtf8(), Event[].class);
-        assertEquals(2, events.length);
-        assertTrue(events[0] instanceof IdentifyEvent);
-        assertTrue(events[1] instanceof CustomEvent);
-        CustomEvent event = (CustomEvent) events[1];
-        assertEquals("userKey", event.userKey);
-        assertEquals("test-event", event.key);
-        assertEquals(System.currentTimeMillis(), event.creationDate, 500);
-        assertNull(event.data);
-        assertNull(event.metricValue);
+            Event[] events = getEventsFromLastRequest(mockEventsServer, 2);
+            assertEquals(2, events.length);
+            assertTrue(events[0] instanceof IdentifyEvent);
+            assertTrue(events[1] instanceof CustomEvent);
+            CustomEvent event = (CustomEvent) events[1];
+            assertEquals("userKey", event.userKey);
+            assertEquals("test-event", event.key);
+            assertNull(event.data);
+            assertNull(event.metricValue);
+        }
     }
 
     @Test
     public void testTrackData() throws IOException, InterruptedException {
-        MockWebServer mockEventsServer = new MockWebServer();
-        mockEventsServer.start();
-        // Enqueue a successful empty response
-        mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
+        try (MockWebServer mockEventsServer = new MockWebServer()) {
+            mockEventsServer.start();
+            // Enqueue a successful empty response
+            mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
 
-        HttpUrl baseUrl = mockEventsServer.url("/mobile");
+            LDConfig ldConfig = baseConfigBuilder(mockEventsServer).build();
+            // Don't wait as we are not set offline
+            try (LDClient client = LDClient.init(application, ldConfig, ldUser, 0)) {
+                JsonPrimitive testData = new JsonPrimitive("abc");
 
-        LDConfig ldConfig = new LDConfig.Builder()
-                .setMobileKey("test-mobile-sdk-key")
-                .setEventsUri(Uri.parse(baseUrl.url().toString()))
-                .build();
+                client.track("test-event", testData);
+                client.blockingFlush();
 
-        // Don't wait as we are not set offline
-        ldClient = LDClient.init(application, ldConfig, ldUser, 0);
-
-        JsonPrimitive testData = new JsonPrimitive("abc");
-
-        ldClient.track("test-event", testData);
-        ldClient.blockingFlush();
-
-        RecordedRequest eventPost = mockEventsServer.takeRequest();
-        assertEquals("POST", eventPost.getMethod());
-        assertEquals("/mobile", eventPost.getPath());
-        assertNotNull(eventPost.getHeader("Authorization"));
-
-        Event[] events = TestUtil.getEventDeserializerGson().fromJson(eventPost.getBody().readUtf8(), Event[].class);
-        assertEquals(2, events.length);
-        assertTrue(events[0] instanceof IdentifyEvent);
-        assertTrue(events[1] instanceof CustomEvent);
-        CustomEvent event = (CustomEvent) events[1];
-        assertEquals("userKey", event.userKey);
-        assertEquals("test-event", event.key);
-        assertEquals(System.currentTimeMillis(), event.creationDate, 500);
-        assertEquals(testData, event.data);
-        assertNull(event.metricValue);
+                Event[] events = getEventsFromLastRequest(mockEventsServer, 2);
+                assertEquals(2, events.length);
+                assertTrue(events[0] instanceof IdentifyEvent);
+                assertTrue(events[1] instanceof CustomEvent);
+                CustomEvent event = (CustomEvent) events[1];
+                assertEquals("userKey", event.userKey);
+                assertEquals("test-event", event.key);
+                assertEquals(testData, event.data);
+                assertNull(event.metricValue);
+            }
+        }
     }
 
     @Test
     public void testTrackDataNull() throws IOException, InterruptedException {
-        MockWebServer mockEventsServer = new MockWebServer();
-        mockEventsServer.start();
-        // Enqueue a successful empty response
-        mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
+        try (MockWebServer mockEventsServer = new MockWebServer()) {
+            mockEventsServer.start();
+            // Enqueue a successful empty response
+            mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
 
-        HttpUrl baseUrl = mockEventsServer.url("/mobile");
+            LDConfig ldConfig = baseConfigBuilder(mockEventsServer).build();
+            try (LDClient client = LDClient.init(application, ldConfig, ldUser, 0)) {
+                client.track("test-event", null);
+                client.blockingFlush();
 
-        LDConfig ldConfig = new LDConfig.Builder()
-                .setMobileKey("test-mobile-sdk-key")
-                .setEventsUri(Uri.parse(baseUrl.url().toString()))
-                .build();
-
-        // Don't wait as we are not set offline
-        ldClient = LDClient.init(application, ldConfig, ldUser, 0);
-
-        ldClient.track("test-event", null);
-        ldClient.blockingFlush();
-
-        RecordedRequest eventPost = mockEventsServer.takeRequest();
-        assertEquals("POST", eventPost.getMethod());
-        assertEquals("/mobile", eventPost.getPath());
-        assertNotNull(eventPost.getHeader("Authorization"));
-
-        Event[] events = TestUtil.getEventDeserializerGson().fromJson(eventPost.getBody().readUtf8(), Event[].class);
-        assertEquals(2, events.length);
-        assertTrue(events[0] instanceof IdentifyEvent);
-        assertTrue(events[1] instanceof CustomEvent);
-        CustomEvent event = (CustomEvent) events[1];
-        assertEquals("userKey", event.userKey);
-        assertEquals("test-event", event.key);
-        assertEquals(System.currentTimeMillis(), event.creationDate, 500);
-        assertNull(event.data);
-        assertNull(event.metricValue);
+                Event[] events = getEventsFromLastRequest(mockEventsServer, 2);
+                assertEquals(2, events.length);
+                assertTrue(events[0] instanceof IdentifyEvent);
+                assertTrue(events[1] instanceof CustomEvent);
+                CustomEvent event = (CustomEvent) events[1];
+                assertEquals("userKey", event.userKey);
+                assertEquals("test-event", event.key);
+                assertNull(event.data);
+                assertNull(event.metricValue);
+            }
+        }
     }
 
     @Test
     public void testTrackMetric() throws IOException, InterruptedException {
-        MockWebServer mockEventsServer = new MockWebServer();
-        mockEventsServer.start();
-        // Enqueue a successful empty response
-        mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
+        try (MockWebServer mockEventsServer = new MockWebServer()) {
+            mockEventsServer.start();
+            // Enqueue a successful empty response
+            mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
 
-        HttpUrl baseUrl = mockEventsServer.url("/mobile");
+            LDConfig ldConfig = baseConfigBuilder(mockEventsServer).build();
+            try (LDClient client = LDClient.init(application, ldConfig, ldUser, 0)) {
+                client.track("test-event", null, 5.5);
+                client.blockingFlush();
 
-        LDConfig ldConfig = new LDConfig.Builder()
-                .setMobileKey("test-mobile-sdk-key")
-                .setEventsUri(Uri.parse(baseUrl.url().toString()))
-                .build();
-
-        // Don't wait as we are not set offline
-        ldClient = LDClient.init(application, ldConfig, ldUser, 0);
-
-        ldClient.track("test-event", null, 5.5);
-        ldClient.blockingFlush();
-
-        RecordedRequest eventPost = mockEventsServer.takeRequest();
-        assertEquals("POST", eventPost.getMethod());
-        assertEquals("/mobile", eventPost.getPath());
-        assertNotNull(eventPost.getHeader("Authorization"));
-
-        Event[] events = TestUtil.getEventDeserializerGson().fromJson(eventPost.getBody().readUtf8(), Event[].class);
-        assertEquals(2, events.length);
-        assertTrue(events[0] instanceof IdentifyEvent);
-        assertTrue(events[1] instanceof CustomEvent);
-        CustomEvent event = (CustomEvent) events[1];
-        assertEquals("userKey", event.userKey);
-        assertEquals("test-event", event.key);
-        assertEquals(System.currentTimeMillis(), event.creationDate, 500);
-        assertNull(event.data);
-        assertEquals(5.5, event.metricValue, 0);
+                Event[] events = getEventsFromLastRequest(mockEventsServer, 2);
+                assertEquals(2, events.length);
+                assertTrue(events[0] instanceof IdentifyEvent);
+                assertTrue(events[1] instanceof CustomEvent);
+                CustomEvent event = (CustomEvent) events[1];
+                assertEquals("userKey", event.userKey);
+                assertEquals("test-event", event.key);
+                assertNull(event.data);
+                assertEquals(5.5, event.metricValue, 0);
+            }
+        }
     }
 
     @Test
     public void testTrackMetricNull() throws IOException, InterruptedException {
-        MockWebServer mockEventsServer = new MockWebServer();
-        mockEventsServer.start();
-        // Enqueue a successful empty response
-        mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
+        try (MockWebServer mockEventsServer = new MockWebServer()) {
+            mockEventsServer.start();
+            // Enqueue a successful empty response
+            mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
 
-        HttpUrl baseUrl = mockEventsServer.url("/mobile");
+            LDConfig ldConfig = baseConfigBuilder(mockEventsServer).build();
+            try (LDClient client = LDClient.init(application, ldConfig, ldUser, 0)) {
+                client.track("test-event", null, null);
+                client.blockingFlush();
 
-        LDConfig ldConfig = new LDConfig.Builder()
-                .setMobileKey("test-mobile-sdk-key")
-                .setEventsUri(Uri.parse(baseUrl.url().toString()))
-                .build();
-
-        // Don't wait as we are not set offline
-        ldClient = LDClient.init(application, ldConfig, ldUser, 0);
-
-        ldClient.track("test-event", null, null);
-        ldClient.blockingFlush();
-
-        RecordedRequest eventPost = mockEventsServer.takeRequest();
-        assertEquals("POST", eventPost.getMethod());
-        assertEquals("/mobile", eventPost.getPath());
-        assertNotNull(eventPost.getHeader("Authorization"));
-
-        Event[] events = TestUtil.getEventDeserializerGson().fromJson(eventPost.getBody().readUtf8(), Event[].class);
-        assertEquals(2, events.length);
-        assertTrue(events[0] instanceof IdentifyEvent);
-        assertTrue(events[1] instanceof CustomEvent);
-        CustomEvent event = (CustomEvent) events[1];
-        assertEquals("userKey", event.userKey);
-        assertEquals("test-event", event.key);
-        assertEquals(System.currentTimeMillis(), event.creationDate, 500);
-        assertNull(event.data);
-        assertNull(event.metricValue);
+                Event[] events = getEventsFromLastRequest(mockEventsServer, 2);
+                assertEquals(2, events.length);
+                assertTrue(events[0] instanceof IdentifyEvent);
+                assertTrue(events[1] instanceof CustomEvent);
+                CustomEvent event = (CustomEvent) events[1];
+                assertEquals("userKey", event.userKey);
+                assertEquals("test-event", event.key);
+                assertNull(event.data);
+                assertNull(event.metricValue);
+            }
+        }
     }
 
     @Test
     public void testTrackDataAndMetric() throws IOException, InterruptedException {
-        MockWebServer mockEventsServer = new MockWebServer();
-        mockEventsServer.start();
-        // Enqueue a successful empty response
-        mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
+        try (MockWebServer mockEventsServer = new MockWebServer()) {
+            mockEventsServer.start();
+            // Enqueue a successful empty response
+            mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
 
-        HttpUrl baseUrl = mockEventsServer.url("/mobile");
+            LDConfig ldConfig = baseConfigBuilder(mockEventsServer).build();
+            try (LDClient client = LDClient.init(application, ldConfig, ldUser, 0)) {
+                JsonObject testData = new JsonObject();
+                testData.add("data", new JsonPrimitive(10));
 
-        LDConfig ldConfig = new LDConfig.Builder()
-                .setMobileKey("test-mobile-sdk-key")
-                .setEventsUri(Uri.parse(baseUrl.url().toString()))
-                .build();
+                client.track("test-event", testData, -10.0);
+                client.blockingFlush();
 
-        // Don't wait as we are not set offline
-        ldClient = LDClient.init(application, ldConfig, ldUser, 0);
-
-        JsonObject testData = new JsonObject();
-        testData.add("data", new JsonPrimitive(10));
-
-        ldClient.track("test-event", testData, -10.0);
-        ldClient.blockingFlush();
-
-        RecordedRequest eventPost = mockEventsServer.takeRequest();
-        assertEquals("POST", eventPost.getMethod());
-        assertEquals("/mobile", eventPost.getPath());
-        assertNotNull(eventPost.getHeader("Authorization"));
-
-        Event[] events = TestUtil.getEventDeserializerGson().fromJson(eventPost.getBody().readUtf8(), Event[].class);
-        assertEquals(2, events.length);
-        assertTrue(events[0] instanceof IdentifyEvent);
-        assertTrue(events[1] instanceof CustomEvent);
-        CustomEvent event = (CustomEvent) events[1];
-        assertEquals("userKey", event.userKey);
-        assertEquals("test-event", event.key);
-        assertEquals(System.currentTimeMillis(), event.creationDate, 500);
-        assertEquals(testData, event.data);
-        assertEquals(-10.0, event.metricValue);
+                Event[] events = getEventsFromLastRequest(mockEventsServer, 2);
+                assertEquals(2, events.length);
+                assertTrue(events[0] instanceof IdentifyEvent);
+                assertTrue(events[1] instanceof CustomEvent);
+                CustomEvent event = (CustomEvent) events[1];
+                assertEquals("userKey", event.userKey);
+                assertEquals("test-event", event.key);
+                assertEquals(testData, event.data);
+                assertEquals(-10.0, event.metricValue);
+            }
+        }
     }
 
     @Test
     public void variationFlagTrackReasonGeneratesEventWithReason() throws IOException, InterruptedException {
-        // Setup events server
-        MockWebServer mockEventsServer = new MockWebServer();
-        mockEventsServer.start();
-        // Enqueue a successful empty response
-        mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
+        try (MockWebServer mockEventsServer = new MockWebServer()) {
+            mockEventsServer.start();
+            // Enqueue a successful empty response
+            mockEventsServer.enqueue(new MockResponse().addHeader("Date", ""));
 
-        HttpUrl baseUrl = mockEventsServer.url("/mobile");
+            LDConfig ldConfig = baseConfigBuilder(mockEventsServer).build();
 
-        String mobileKey = "test-mobile-key";
-        LDConfig ldConfig = new LDConfig.Builder()
-                .setMobileKey(mobileKey)
-                .setEventsUri(Uri.parse(baseUrl.url().toString()))
-                .build();
+            // Setup flag store with test flag
+            TestUtil.markMigrationComplete(application);
+            EvaluationReason testReason = EvaluationReason.off();
+            FlagStore flagStore = new SharedPrefsFlagStoreFactory(application).createFlagStore(mobileKey + ldUser.getSharedPrefsKey());
+            flagStore.applyFlagUpdate(new FlagBuilder("track-reason-flag").trackEvents(true).trackReason(true).reason(testReason).build());
 
-        // Setup flag store with test flag
-        TestUtil.markMigrationComplete(application);
-        EvaluationReason testReason = EvaluationReason.off();
-        FlagStore flagStore = new SharedPrefsFlagStoreFactory(application).createFlagStore(mobileKey + ldUser.getSharedPrefsKey());
-        flagStore.applyFlagUpdate(new FlagBuilder("track-reason-flag").trackEvents(true).trackReason(true).reason(testReason).build());
+            try (LDClient client = LDClient.init(application, ldConfig, ldUser, 0)) {
+                client.boolVariation("track-reason-flag", false);
+                client.blockingFlush();
 
-        // Don't wait as we are not set offline
-        ldClient = LDClient.init(application, ldConfig, ldUser, 0);
+                Event[] events = getEventsFromLastRequest(mockEventsServer, 3);
+                assertEquals(3, events.length);
+                assertTrue(events[0] instanceof IdentifyEvent);
+                assertTrue(events[1] instanceof FeatureRequestEvent);
+                FeatureRequestEvent event = (FeatureRequestEvent) events[1];
+                assertEquals("track-reason-flag", event.key);
+                assertEquals("userKey", event.userKey);
+                assertNull(event.variation);
+                assertNull(event.version);
+                assertFalse(event.value.getAsBoolean());
+                assertFalse(event.defaultVal.getAsBoolean());
+                assertEquals(testReason, event.reason);
+                assertTrue(events[2] instanceof SummaryEvent);
+            }
+        }
+    }
 
-        ldClient.boolVariation("track-reason-flag", false);
-        ldClient.blockingFlush();
+    private Event[] getEventsFromLastRequest(MockWebServer server, int expectedCount) throws InterruptedException {
+        RecordedRequest r = server.takeRequest();
+        assertEquals("POST", r.getMethod());
+        assertEquals("/mobile", r.getPath());
+        assertEquals(LDConfig.AUTH_SCHEME + mobileKey, r.getHeader("Authorization"));
+        String body = r.getBody().readUtf8();
+        System.out.println(body);
+        Event[] events = TestUtil.getEventDeserializerGson().fromJson(body, Event[].class);
+        if (events.length != expectedCount) {
+            assertTrue("count should be " + expectedCount + " for: " + body, false);
+        }
+        return events;
+    }
 
-        RecordedRequest eventPost = mockEventsServer.takeRequest();
-        assertEquals("POST", eventPost.getMethod());
-        assertEquals("/mobile", eventPost.getPath());
-        assertNotNull(eventPost.getHeader("Authorization"));
-
-        Event[] events = TestUtil.getEventDeserializerGson().fromJson(eventPost.getBody().readUtf8(), Event[].class);
-        assertEquals(3, events.length);
-        assertTrue(events[0] instanceof IdentifyEvent);
-        assertTrue(events[1] instanceof FeatureRequestEvent);
-        FeatureRequestEvent event = (FeatureRequestEvent) events[1];
-        assertEquals("track-reason-flag", event.key);
-        assertEquals("userKey", event.userKey);
-        assertNull(event.variation);
-        assertNull(event.version);
-        assertFalse(event.value.getAsBoolean());
-        assertFalse(event.defaultVal.getAsBoolean());
-        assertEquals(testReason, event.reason);
-        assertEquals(System.currentTimeMillis(), event.creationDate, 500);
-        assertTrue(events[2] instanceof SummaryEvent);
+    private LDConfig.Builder baseConfigBuilder(MockWebServer server) {
+        HttpUrl baseUrl = server.url("/mobile");
+        return new LDConfig.Builder()
+            .setMobileKey(mobileKey)
+            .setEventsUri(Uri.parse(baseUrl.toString()));
     }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/DefaultEventProcessor.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/DefaultEventProcessor.java
@@ -87,7 +87,7 @@ class DefaultEventProcessor implements EventProcessor, Closeable {
                 }
             });
 
-            scheduler.scheduleAtFixedRate(consumer, 0, config.getEventsFlushIntervalMillis(), TimeUnit.MILLISECONDS);
+            scheduler.scheduleAtFixedRate(consumer, config.getEventsFlushIntervalMillis(), config.getEventsFlushIntervalMillis(), TimeUnit.MILLISECONDS);
         }
     }
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/Foreground.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/Foreground.java
@@ -20,16 +20,16 @@ import static android.app.ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIB
 
 /**
  * Usage:
- * <p/>
+ * <p>
  * 1. Get the Foreground Singleton, passing a Context or Application object unless you
  * are sure that the Singleton has definitely already been initialised elsewhere.
- * <p/>
+ * <p>
  * 2.a) Perform a direct, synchronous check: Foreground.isForeground() / .isBackground()
- * <p/>
+ * <p>
  * or
- * <p/>
+ * <p>
  * 2.b) Register to be notified (useful in Service or other non-UI components):
- * <p/>
+ * <p>
  * Foreground.Listener myListener = new Foreground.Listener(){
  * void onBecameForeground(){
  * // ... whatever you want to do
@@ -38,12 +38,12 @@ import static android.app.ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIB
  * // ... whatever you want to do
  * }
  * }
- * <p/>
+ * <p>
  * void onCreate(){
  * super.onCreate();
  * Foreground.get(this).addListener(listener);
  * }
- * <p/>
+ * <p>
  * void onDestroy(){
  * super.onCreate();
  * Foreground.get(this).removeListener(listener);

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDClient.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDClient.java
@@ -58,7 +58,7 @@ public class LDClient implements LDClientInterface, Closeable {
      * will complete once the client has been initialized with the latest feature flag values. For
      * immediate access to the Client (possibly with out of date feature flags), it is safe to ignore
      * the return value of this method, and afterward call {@link #get()}
-     * <p/>
+     * <p>
      * If the client has already been initialized, is configured for offline mode, or the device is
      * not connected to the internet, this method will return a {@link Future} that is
      * already in the completed state.
@@ -401,7 +401,7 @@ public class LDClient implements LDClientInterface, Closeable {
     /**
      * Closes the client. This should only be called at the end of a client's lifecycle.
      *
-     * @throws IOException
+     * @throws IOException declared by the Closeable interface, but will not be thrown by the client
      */
     @Override
     public void close() throws IOException {

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDClientInterface.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDClientInterface.java
@@ -37,7 +37,7 @@ public interface LDClientInterface extends Closeable {
      * Shuts down any network connections maintained by the client and puts the client in offline
      * mode, preventing the client from opening new network connections until
      * <code>setOnline()</code> is called.
-     * <p/>
+     * <p>
      * Note: The client automatically monitors the device's network connectivity and app foreground
      * status, so calling <code>setOffline()</code> or <code>setOnline()</code> is normally
      * unnecessary in most situations.
@@ -47,7 +47,7 @@ public interface LDClientInterface extends Closeable {
     /**
      * Restores network connectivity for the client, if the client was previously in offline mode.
      * This operation may be throttled if it is called too frequently.
-     * <p/>
+     * <p>
      * Note: The client automatically monitors the device's network connectivity and app foreground
      * status, so calling <code>setOffline()</code> or <code>setOnline()</code> is normally
      * unnecessary in most situations.
@@ -274,14 +274,14 @@ public interface LDClientInterface extends Closeable {
     ConnectionInformation getConnectionInformation();
 
     /**
-     *
-     * @param LDStatusListener
+     * Unregisters a {@link LDStatusListener} so it will no longer be called on connection status updates.
+     * @param LDStatusListener the listener to be removed
      */
     void unregisterStatusListener(LDStatusListener LDStatusListener);
 
     /**
-     *
-     * @param LDStatusListener
+     * Registers a {@link LDStatusListener} to be called on connection status updates.
+     * @param LDStatusListener the listener to be called on a connection status update
      */
     void registerStatusListener(LDStatusListener LDStatusListener);
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDConfig.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDConfig.java
@@ -418,6 +418,7 @@ public class LDConfig {
          *
          * @param backgroundPollingIntervalMillis the feature flag polling interval when in the background,
          *                                        in milliseconds
+         * @return the builder
          */
         public LDConfig.Builder setBackgroundPollingIntervalMillis(int backgroundPollingIntervalMillis) {
             this.backgroundPollingIntervalMillis = backgroundPollingIntervalMillis;
@@ -430,6 +431,7 @@ public class LDConfig {
          * The default value is false (flag updates <i>will</i> be done in the background).
          *
          * @param disableBackgroundUpdating true if the client should skip updating flags when in the background
+         * @return the builder
          */
         public LDConfig.Builder setDisableBackgroundUpdating(boolean disableBackgroundUpdating) {
             this.disableBackgroundUpdating = disableBackgroundUpdating;

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDCountryCode.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDCountryCode.java
@@ -96,8 +96,6 @@ import java.util.regex.Pattern;
  *
  * @author Takahiko Kawasaki
  */
-@SuppressWarnings({"deprecation", "DeprecatedIsStillUsed"})
-@Deprecated
 public enum LDCountryCode {
     /**
      * <a href="http://en.wikipedia.org/wiki/Ascension_Island">Ascension Island</a>

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDCountryCode.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDCountryCode.java
@@ -33,7 +33,6 @@ import java.util.regex.Pattern;
 
 /**
  * <a href="http://en.wikipedia.org/wiki/ISO_3166-1">ISO 3166-1</a> country code.
- * <p/>
  * <p>
  * Enum names of this enum themselves are represented by
  * <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO 3166-1 alpha-2</a>
@@ -47,7 +46,6 @@ import java.util.regex.Pattern;
  * corresponds to a given alpha-2/alpha-3/numeric code ({@link #getByCode(String)},
  * {@link #getByCode(int)}).
  * </p>
- * <p/>
  * <pre style="background-color: #EEEEEE; margin-left: 2em; margin-right: 2em; border: 1px solid black; padding: 0.5em;">
  * <span style="color: darkgreen;">// List all the country codes.</span>
  * for (CountryCode code : CountryCode.values())
@@ -55,10 +53,10 @@ import java.util.regex.Pattern;
  * <span style="color: darkgreen;">// For example, "[US] United States" is printed.</span>
  * System.out.format(<span style="color: darkred;">"[%s] %s\n"</span>, code, code.{@link #getName()});
  * }
- * <p/>
+ * 
  * <span style="color: darkgreen;">// Get a CountryCode instance by ISO 3166-1 code.</span>
  * CountryCode code = CountryCode.{@link #getByCode(String) getByCode}(<span style="color: darkred;">"JP"</span>);
- * <p/>
+ * 
  * <span style="color: darkgreen;">// Print all the information. Output will be:</span>
  * <span style="color: darkgreen;">//</span>
  * <span style="color: darkgreen;">//     Country name            = Japan</span>
@@ -72,16 +70,16 @@ import java.util.regex.Pattern;
  * System.out.println(<span style="color: darkred;">"ISO 3166-1 alpha-3 code = "</span> + code.{@link #getAlpha3()});
  * System.out.println(<span style="color: darkred;">"ISO 3166-1 numeric code = "</span> + code.{@link #getNumeric()});
  * System.out.println(<span style="color: darkred;">"Assignment state        = "</span> + code.{@link #getAssignment()});
- * <p/>
+ * 
  * <span style="color: darkgreen;">// Convert to a Locale instance.</span>
  * {@link Locale} locale = code.{@link #toLocale()};
- * <p/>
+ * 
  * <span style="color: darkgreen;">// Get a CountryCode by a Locale instance.</span>
  * code = CountryCode.{@link #getByLocale(Locale) getByLocale}(locale);
- * <p/>
+ * 
  * <span style="color: darkgreen;">// Get the currency of the country.</span>
  * {@link Currency} currency = code.{@link #getCurrency()};
- * <p/>
+ * 
  * <span style="color: darkgreen;">// Get a list by a regular expression for names.
  * //
  * // The list will contain:
@@ -1818,7 +1816,6 @@ public enum LDCountryCode {
      * <a href="http://en.wikipedia.org/wiki/East_Timor">East Timor</a>
      * [<a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#TP">TP</a>, TPTL, 0,
      * Traditionally reserved]
-     * <p/>
      * <p>
      * ISO 3166-1 numeric code is unknown.
      * </p>
@@ -2033,7 +2030,6 @@ public enum LDCountryCode {
      * <a href="http://en.wikipedia.org/wiki/Zaire">Zaire</a>
      * [<a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#ZR">ZR</a>, ZRCD, 0,
      * Traditionally reserved]
-     * <p/>
      * <p>
      * ISO 3166-1 numeric code is unknown.
      * </p>
@@ -2059,7 +2055,7 @@ public enum LDCountryCode {
         /**
          * <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements"
          * >Officially assigned</a>.
-         * <p/>
+         * <p>
          * Assigned to a country, territory, or area of geographical interest.
          */
         OFFICIALLY_ASSIGNED,
@@ -2067,7 +2063,7 @@ public enum LDCountryCode {
         /**
          * <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#User-assigned_code_elements"
          * >User assigned</a>.
-         * <p/>
+         * <p>
          * Free for assignment at the disposal of users.
          */
         USER_ASSIGNED,
@@ -2075,7 +2071,7 @@ public enum LDCountryCode {
         /**
          * <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Exceptional_reservations"
          * >Exceptionally reserved</a>.
-         * <p/>
+         * <p>
          * Reserved on request for restricted use.
          */
         EXCEPTIONALLY_RESERVED,
@@ -2083,7 +2079,7 @@ public enum LDCountryCode {
         /**
          * <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Transitional_reservations"
          * >Transitionally reserved</a>.
-         * <p/>
+         * <p>
          * Deleted from ISO 3166-1 but reserved transitionally.
          */
         TRANSITIONALLY_RESERVED,
@@ -2091,7 +2087,7 @@ public enum LDCountryCode {
         /**
          * <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Indeterminate_reservations"
          * >Indeterminately reserved</a>.
-         * <p/>
+         * <p>
          * Used in coding systems associated with ISO 3166-1.
          */
         INDETERMINATELY_RESERVED,
@@ -2099,7 +2095,7 @@ public enum LDCountryCode {
         /**
          * <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Codes_currently_agreed_not_to_use"
          * >Not used</a>.
-         * <p/>
+         * <p>
          * Not used in ISO 3166-1 in deference to international property
          * organization names.
          */
@@ -2202,22 +2198,19 @@ public enum LDCountryCode {
 
     /**
      * Convert this {@code CountryCode} instance to a {@link Locale} instance.
-     * <p/>
      * <p>
      * In most cases, this method creates a new {@code Locale} instance
      * every time it is called, but some {@code CountryCode} instances return
      * their corresponding entries in {@code Locale} class. For example,
      * {@link #CA CountryCode.CA} always returns {@link Locale#CANADA}.
      * </p>
-     * <p/>
      * <p>
      * The table below lists {@code CountryCode} entries whose {@code toLocale()}
      * do not create new Locale instances but return entries in
      * {@code Locale} class.
      * </p>
-     * <p/>
      * <table border="1" style="border-collapse: collapse;" cellpadding="5" summary="">
-     * <tr bgcolor="#FF8C00">
+     * <tr>
      * <th>CountryCode</th>
      * <th>Locale</th>
      * </tr>
@@ -2272,7 +2265,6 @@ public enum LDCountryCode {
 
     /**
      * Get the currency.
-     * <p/>
      * <p>
      * This method is an alias of {@link Currency}{@code .}{@link
      * Currency#getInstance(Locale) getInstance}{@code (}{@link
@@ -2280,13 +2272,11 @@ public enum LDCountryCode {
      * returns {@code null} when {@code Currency.getInstance(Locale)}
      * throws {@code IllegalArgumentException}.
      * </p>
-     * <p/>
      * <p>
      * This method returns {@code null} when the territory represented by
      * this {@code CountryCode} instance does not have a currency.
      * {@link #AQ} (Antarctica) is one example.
      * </p>
-     * <p/>
      * <p>
      * In addition, this method returns {@code null} also when the ISO 3166
      * code represented by this {@code CountryCode} instance is not
@@ -2315,7 +2305,6 @@ public enum LDCountryCode {
      * Get a {@code CountryCode} that corresponds to the given ISO 3166-1
      * <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">alpha-2</a> or
      * <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-3">alpha-3</a> code.
-     * <p/>
      * <p>
      * This method calls {@link #getByCode(String, boolean) getByCode}{@code (code, true)}.
      * Note that the behavior has changed since the version 1.13. In the older versions,
@@ -2337,7 +2326,6 @@ public enum LDCountryCode {
      * Get a {@code CountryCode} that corresponds to the given ISO 3166-1
      * <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">alpha-2</a> or
      * <a href="http://en.wikipedia.org/wiki/ISO_3166-1_alpha-3">alpha-3</a> code.
-     * <p/>
      * <p>
      * This method calls {@link #getByCode(String, boolean) getByCode}{@code (code, false)}.
      * </p>
@@ -2467,7 +2455,6 @@ public enum LDCountryCode {
 
     /**
      * Get a list of {@code CountryCode} by a name regular expression.
-     * <p/>
      * <p>
      * This method is almost equivalent to {@link #findByName(Pattern)
      * findByName}{@code (Pattern.compile(regex))}.
@@ -2495,19 +2482,15 @@ public enum LDCountryCode {
 
     /**
      * Get a list of {@code CountryCode} by a name pattern.
-     * <p/>
      * <p>
      * For example, the list obtained by the code snippet below:
      * </p>
-     * <p/>
      * <pre style="background-color: #EEEEEE; margin-left: 2em; margin-right: 2em; border: 1px solid black; padding: 0.5em;">
      * Pattern pattern = Pattern.compile(<span style="color: darkred;">".*United.*"</span>);
      * List&lt;CountryCode&gt; list = CountryCode.findByName(pattern);</pre>
-     * <p/>
      * <p>
      * contains 6 {@code CountryCode}s as listed below.
      * </p>
-     * <p/>
      * <ol>
      * <li>{@link #AE} : United Arab Emirates
      * <li>{@link #GB} : United Kingdom

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDCountryCode.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDCountryCode.java
@@ -96,6 +96,8 @@ import java.util.regex.Pattern;
  *
  * @author Takahiko Kawasaki
  */
+@SuppressWarnings({"deprecation", "DeprecatedIsStillUsed"})
+@Deprecated
 public enum LDCountryCode {
     /**
      * <a href="http://en.wikipedia.org/wiki/Ascension_Island">Ascension Island</a>

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDUser.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDUser.java
@@ -29,12 +29,12 @@ import timber.log.Timber;
  * mandatory property property is the {@code key}, which must uniquely identify each user. For
  * authenticated users, this may be a username or e-mail address. For anonymous users, this could be
  * an IP address or session ID.
- * <p/>
+ * <p>
  * Besides the mandatory {@code key}, {@code LDUser} supports two kinds of optional attributes:
  * interpreted attributes (e.g. {@code ip} and {@code country}) and custom attributes.  LaunchDarkly
  * can parse interpreted attributes and attach meaning to them. For example, from an {@code ip}
  * address, LaunchDarkly can do a geo IP lookup and determine the user's country.
- * <p/>
+ * <p>
  * Custom attributes are not parsed by LaunchDarkly. They can be used in custom rules-- for example,
  * a custom attribute such as "customer_ranking" can be used to launch a feature to the top 10% of
  * users on a site.
@@ -192,7 +192,6 @@ public class LDUser {
     /**
      * A <a href="http://en.wikipedia.org/wiki/Builder_pattern">builder</a> that helps construct
      * {@link LDUser} objects. Builder calls can be chained, enabling the following pattern:
-     * <p/>
      * <pre>
      * LDUser user = new LDUser.Builder("key")
      *      .country("US")

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDUser.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDUser.java
@@ -211,6 +211,7 @@ public class LDUser {
         private String email;
         private String name;
         private String avatar;
+        @SuppressWarnings("deprecation")
         private LDCountryCode country;
 
         private final Map<String, JsonElement> custom;
@@ -232,6 +233,7 @@ public class LDUser {
             privateAttributeNames = new HashSet<>();
         }
 
+        @SuppressWarnings("deprecation")
         public Builder(LDUser user) {
             this.key = user.getKey();
             this.anonymous = user.getAnonymous();
@@ -282,10 +284,12 @@ public class LDUser {
         }
 
         /**
-         * Set the country for a user. The country should be a valid <a
+         * Set the country for a user. In 2.x.x the SDK will attempt to look the country up as a <a
          * href="http://en.wikipedia.org/wiki/ISO_3166-1">ISO 3166-1</a> alpha-2 or alpha-3 code. If
          * it is not a valid ISO-3166-1 code, an attempt will be made to look up the country by its
-         * name. If that fails, a warning will be logged, and the country will not be set.
+         * name. If that fails, a warning will be logged, and the country will not be set. In the
+         * next major release (3.0.0) the SDK will not attempt attempt this lookup, and instead
+         * treat the country field as a normal String.
          *
          * @param s the country for the user
          * @return the builder
@@ -296,11 +300,12 @@ public class LDUser {
         }
 
         /**
-         * Set the country for a user. The country should be a valid <a
+         * Set the country for a user. In 2.x.x the SDK will attempt to look the country up as a <a
          * href="http://en.wikipedia.org/wiki/ISO_3166-1">ISO 3166-1</a> alpha-2 or alpha-3 code. If
          * it is not a valid ISO-3166-1 code, an attempt will be made to look up the country by its
-         * name. If that fails, a warning will be logged, and the country will not be set. Private
-         * attributes are not recorded in events.
+         * name. If that fails, a warning will be logged, and the country will not be set. In the
+         * next major release (3.0.0) the SDK will not attempt attempt this lookup, and instead
+         * treat the country field as a normal String. Private attributes are not recorded in events.
          *
          * @param s the country for the user
          * @return the builder
@@ -310,6 +315,8 @@ public class LDUser {
             return country(s);
         }
 
+
+        @SuppressWarnings("deprecation")
         private LDCountryCode countryCode(String s) {
             LDCountryCode countryCode = LDCountryCode.getByCode(s, false);
 
@@ -341,7 +348,11 @@ public class LDUser {
          *
          * @param country the country for the user
          * @return the builder
-         */
+         * @deprecated As of version 2.9.1, in 3.0.0 the SDK will no longer include the
+         * LDCountryCode class. Applications should use {@link #country(String)} instead.
+         * */
+        @Deprecated
+        @SuppressWarnings("deprecation")
         public Builder country(LDCountryCode country) {
             this.country = country;
             return this;
@@ -352,7 +363,11 @@ public class LDUser {
          *
          * @param country the country for the user
          * @return the builder
+         * @deprecated As of version 2.9.1, in 3.0.0 the SDK will no longer include the
+         * LDCountryCode class. Applications should use {@link #privateCountry(String)} instead.
          */
+        @Deprecated
+        @SuppressWarnings("deprecation")
         public Builder privateCountry(LDCountryCode country) {
             privateAttributeNames.add(COUNTRY);
             return country(country);

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDUser.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/LDUser.java
@@ -211,7 +211,6 @@ public class LDUser {
         private String email;
         private String name;
         private String avatar;
-        @SuppressWarnings("deprecation")
         private LDCountryCode country;
 
         private final Map<String, JsonElement> custom;
@@ -233,7 +232,6 @@ public class LDUser {
             privateAttributeNames = new HashSet<>();
         }
 
-        @SuppressWarnings("deprecation")
         public Builder(LDUser user) {
             this.key = user.getKey();
             this.anonymous = user.getAnonymous();
@@ -284,12 +282,10 @@ public class LDUser {
         }
 
         /**
-         * Set the country for a user. In 2.x.x the SDK will attempt to look the country up as a <a
+         * Set the country for a user. The country should be a valid <a
          * href="http://en.wikipedia.org/wiki/ISO_3166-1">ISO 3166-1</a> alpha-2 or alpha-3 code. If
          * it is not a valid ISO-3166-1 code, an attempt will be made to look up the country by its
-         * name. If that fails, a warning will be logged, and the country will not be set. In the
-         * next major release (3.0.0) the SDK will not attempt attempt this lookup, and instead
-         * treat the country field as a normal String.
+         * name. If that fails, a warning will be logged, and the country will not be set.
          *
          * @param s the country for the user
          * @return the builder
@@ -300,12 +296,11 @@ public class LDUser {
         }
 
         /**
-         * Set the country for a user. In 2.x.x the SDK will attempt to look the country up as a <a
+         * Set the country for a user. The country should be a valid <a
          * href="http://en.wikipedia.org/wiki/ISO_3166-1">ISO 3166-1</a> alpha-2 or alpha-3 code. If
          * it is not a valid ISO-3166-1 code, an attempt will be made to look up the country by its
-         * name. If that fails, a warning will be logged, and the country will not be set. In the
-         * next major release (3.0.0) the SDK will not attempt attempt this lookup, and instead
-         * treat the country field as a normal String. Private attributes are not recorded in events.
+         * name. If that fails, a warning will be logged, and the country will not be set. Private
+         * attributes are not recorded in events.
          *
          * @param s the country for the user
          * @return the builder
@@ -315,8 +310,6 @@ public class LDUser {
             return country(s);
         }
 
-
-        @SuppressWarnings("deprecation")
         private LDCountryCode countryCode(String s) {
             LDCountryCode countryCode = LDCountryCode.getByCode(s, false);
 
@@ -348,11 +341,7 @@ public class LDUser {
          *
          * @param country the country for the user
          * @return the builder
-         * @deprecated As of version 2.9.1, in 3.0.0 the SDK will no longer include the
-         * LDCountryCode class. Applications should use {@link #country(String)} instead.
-         * */
-        @Deprecated
-        @SuppressWarnings("deprecation")
+         */
         public Builder country(LDCountryCode country) {
             this.country = country;
             return this;
@@ -363,11 +352,7 @@ public class LDUser {
          *
          * @param country the country for the user
          * @return the builder
-         * @deprecated As of version 2.9.1, in 3.0.0 the SDK will no longer include the
-         * LDCountryCode class. Applications should use {@link #privateCountry(String)} instead.
          */
-        @Deprecated
-        @SuppressWarnings("deprecation")
         public Builder privateCountry(LDCountryCode country) {
             privateAttributeNames.add(COUNTRY);
             return country(country);

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/PollingUpdater.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/PollingUpdater.java
@@ -33,11 +33,15 @@ public class PollingUpdater extends BroadcastReceiver {
         PendingIntent pendingIntent = getPendingIntent(context);
         AlarmManager alarmMgr = getAlarmManager(context);
 
-        alarmMgr.setInexactRepeating(
-                AlarmManager.ELAPSED_REALTIME,
-                SystemClock.elapsedRealtime() + initialDelayMillis,
-                intervalMillis,
-                pendingIntent);
+        try {
+            alarmMgr.setInexactRepeating(
+                    AlarmManager.ELAPSED_REALTIME,
+                    SystemClock.elapsedRealtime() + initialDelayMillis,
+                    intervalMillis,
+                    pendingIntent);
+        } catch (SecurityException ex) {
+            Timber.w(ex, "SecurityException when setting background polling alarm");
+        }
     }
 
     synchronized static void stop(Context context) {

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/SummaryEventSharedPreferences.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/SummaryEventSharedPreferences.java
@@ -5,9 +5,8 @@ import android.support.annotation.Nullable;
 import com.google.gson.JsonElement;
 
 /**
- * Created by jamesthacker on 4/12/18.
+ * Used internally by the SDK.
  */
-
 public interface SummaryEventSharedPreferences {
 
     void clear();

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/response/FlagsResponse.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/android/response/FlagsResponse.java
@@ -7,9 +7,7 @@ import com.launchdarkly.android.flagstore.Flag;
 import java.util.List;
 
 /**
- * Used for cases where the server sends a collection of flags as a key-value object. Uses custom
- * deserializer in {@link com.launchdarkly.android.gson.FlagsResponseSerialization} to get a list of
- * {@link com.launchdarkly.android.flagstore.Flag} objects.
+ * Used for cases where the server sends a collection of flags as a key-value object.
  */
 public class FlagsResponse {
     @NonNull


### PR DESCRIPTION
## [2.9.1] - 2020-01-03
### Fixed:
- Removed possibility of fatal `SecurityException` on Samsung devices that would be triggered when the SDK attempted to register an alarm to trigger a future poll when the application process already had 500 alarms registered. This limit is only present on Samsung's versions of Android Lollipop and later. The SDK will now catch this error if it occurs to prevent killing the host application.
- Rarely, the client would deliver its initial "identify" event to LaunchDarkly immediately rather than waiting for the configured flush interval.
- Fixed some malformed Javadoc comments.
