### PR TITLE
Let consumer projects add gms play service dependency

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -50,5 +50,10 @@ dependencies {
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
 
+    // Explicitly old version of Google Play Services to allow compatibility without update for
+    // older phones
+    //noinspection GradleDependency
+    implementation 'com.google.android.gms:play-services-base:6.5.87'
+
     testImplementation 'junit:junit:4.12'
 }

--- a/launchdarkly-android-client-sdk/build.gradle
+++ b/launchdarkly-android-client-sdk/build.gradle
@@ -71,7 +71,9 @@ dependencies {
     implementation "com.launchdarkly:okhttp-eventsource:$eventsourceVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.jakewharton.timber:timber:4.7.1"
-    
+
+    // Explicitly old version of Google Play Services to allow compatibility without update for
+    // older phones. Consumer projects will need to add this dependency
     //noinspection GradleDependency
     compileOnly 'com.google.android.gms:play-services-base:6.5.87'
 

--- a/launchdarkly-android-client-sdk/build.gradle
+++ b/launchdarkly-android-client-sdk/build.gradle
@@ -71,10 +71,9 @@ dependencies {
     implementation "com.launchdarkly:okhttp-eventsource:$eventsourceVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"
     implementation "com.jakewharton.timber:timber:4.7.1"
-    // Explicitly old version of Google Play Services to allow compatibility without update for
-    // older phones
+    
     //noinspection GradleDependency
-    implementation 'com.google.android.gms:play-services-base:6.5.87'
+    compileOnly 'com.google.android.gms:play-services-base:6.5.87'
 
     androidTestUtil "com.android.support.test:orchestrator:$testRunnerVersion"
     androidTestImplementation "com.android.support:appcompat-v7:$supportVersion"


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Google's play services library has evolved (now served as plugins) and `launchdarkly`'s dependency on very older version of `play-services-base:6.5.87` is not necessary for all consumer projects. However, `launchdarkly` library still needs to depend on it for code to compile hence making it `compileOnly` dependency and let consumer (example app here) add it. 

**Describe alternatives you've considered**
 
I have tried adding gradle capabilities to resolve conflicts but solution doesn't fit well in multi-repo libraries.

**Additional context**
- Gradle is unable to resolve version conflicts since older version is a lib dependency and latest play services are served as plugins.  

