### PR TITLE
Fix isInternetConnected return false when user connect wifi and vpn (below Android 10)

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDUtil.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDUtil.java
@@ -50,6 +50,7 @@ class LDUtil {
                                 || nwc.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
                                 || nwc.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
                                 || nwc.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)
+                                || nwc.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
                 );
             } else {
                 NetworkInfo active = cm.getActiveNetworkInfo();


### PR DESCRIPTION


**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

When user devices(below Android 10) connect wifi and vpn, the isInternetConnected method will return false and 
caused LD to not work.
So I add nwc.hasTransport(NetworkCapabilities.TRANSPORT_VPN) to perfect this logical judgment.

**Describe alternatives you've considered**

N/A

**Additional context**

N/A