### PR TITLE
Update timber version to the 5.0.1

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation("androidx.appcompat:appcompat:1.2.0")
-    implementation("com.jakewharton.timber:timber:4.7.1")
+    implementation("com.jakewharton.timber:timber:5.0.1")
 
     implementation(project(":launchdarkly-android-client-sdk"))
     // Comment the previous line and uncomment this one to depend on the published artifact:

--- a/launchdarkly-android-client-sdk/build.gradle
+++ b/launchdarkly-android-client-sdk/build.gradle
@@ -66,7 +66,7 @@ ext.versions = [
     "junit": "4.13",
     "launchdarklyJavaSdkCommon": "1.2.0",
     "okhttp": "4.9.1",
-    "timber": "4.7.1",
+    "timber": "5.0.1",
 ]
 
 dependencies {


### PR DESCRIPTION
Found that when we added launchdarkly to our project we've started observe new errors:
Using "'Log' instead of 'Timber'" Danger error.
But we didn't have Timber in our project.
After run dependency check I've found that launchdarkly contains timber.

| | | | | | +--- com.launchdarkly:**launchdarkly**-android-client-sdk:2.14.2
| | | | | | | +--- com.google.code.gson:gson:2.8.2 -> 2.8.6
| | | | | | | +--- com.launchdarkly:okhttp-eventsource:1.8.0
| | | | | | | | +--- com.squareup.okhttp3:okhttp:3.8.1 -> 3.14.7 ()
| | | | | | | | +--- org.slf4j:slf4j-api:1.7.22 -> 1.7.25
| | | | | | | | --- com.google.code.findbugs:jsr305:3.0.2
| | | | | | | +--- com.squareup.okhttp3:okhttp:3.12.2 -> 3.14.7 ()
| | | | | | | +--- com.jakewharton.**timber**:timber:4.7.1

And there is issue in Timber that was already fixed JakeWharton/timber#380

After I've added latest timber version implementation 'com.jakewharton.timber:timber:5.0.1'
This errors disapears.
Using "'Log' instead of 'Timber'" Danger error.