### PR TITLE
Fix NullPointerException when event buffer is full

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
@@ -664,7 +664,9 @@ public class LDClient implements LDClientInterface, Closeable {
             boolean processed = eventProcessor.sendEvent(event);
             if (!processed) {
                 LDConfig.LOG.w("Exceeded event queue capacity. Increase capacity to avoid dropping events.");
-                diagnosticStore.incrementDroppedEventCount();
+                if (diagnosticStore != null) {
+                    diagnosticStore.incrementDroppedEventCount();
+                }
             }
         }
     }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

When `diagnosticOptOut` is `true` and the events buffer is full, a null pointer exception will be thrown when trying to send an event. Example stacktrace:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'void com.launchdarkly.sdk.android.DiagnosticStore.incrementDroppedEventCount()' on a null object reference
at com.launchdarkly.sdk.android.LDClient.sendEvent(LDClient.java:668)
at com.launchdarkly.sdk.android.LDClient.identifyInternal(LDClient.java:314)
at com.launchdarkly.sdk.android.LDClient.identifyInstances(LDClient.java:335)
at com.launchdarkly.sdk.android.LDClient.identify(LDClient.java:301)
at com.launchdarkly.sdk.android.LDClientTest.testEventBufferFillsUp(LDClientTest.java:661)
```

This occurs because `diagnosticStore` is set to `null` when `diagnosticOptOut` is `true` (see [here](https://github.com/launchdarkly/android-client-sdk/blob/a2886cd85349ef67e9f60773bb5725bac90798db/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java#L247:L253)) and `sendEvent()` assumes `diagnosticStore` will not be `null` (see [here](https://github.com/launchdarkly/android-client-sdk/blob/a2886cd85349ef67e9f60773bb5725bac90798db/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java#L667))

Other usages of `diagnosticStore` are gated with `if (diagnosticStore != null)` to avoid throwing an exception (see [here](https://github.com/launchdarkly/android-client-sdk/blob/a2886cd85349ef67e9f60773bb5725bac90798db/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/StreamUpdateProcessor.java#L63:L65) and [here](https://github.com/launchdarkly/android-client-sdk/blob/a2886cd85349ef67e9f60773bb5725bac90798db/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/DefaultEventProcessor.java#L129:L131))

This pull request adds a similar gate to avoid the null pointer exception.

**Describe alternatives you've considered**

N/A

**Additional context**

N/A
