### PR TITLE
Do not syncrhonize Throttler::run

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/Throttler.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/Throttler.java
@@ -32,7 +32,7 @@ class Throttler {
         this.maxRetryTimeMs = maxRetryTimeMs;
     }
 
-    private synchronized void run() {
+    private void run() {
         taskRunnable.run();
     }
 


### PR DESCRIPTION

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

See: #162 

**Describe the solution you've provided**

Throttler::run and Throttler::attemptRun are the two functions that can syncrhonize both itself and
ConnectivityManager in that order, ConnectivityManager itself usually syncrhonizes on
itself then on Throttler by calling its functions. Because Throttler::run is run on a separate
thread this becomes a problem as the order of locking is different. Removing synchronize
from Throttler::run will restore the order as the runnable will lock ConnectivityManager.
Throttler::attemptRun is only called from ConnectivityManager and after it locks ConnectivityManager
so Throttler::attemptRun should not require any changes.

**Describe alternatives you've considered**

No alternatives considered
