### PR TITLE
Set LaunchDarklySdk tag for all Timber events

### DIFF
--- a/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/TimberLoggingTest.java
+++ b/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/TimberLoggingTest.java
@@ -1,0 +1,56 @@
+package com.launchdarkly.sdk.android;
+
+import static org.junit.Assert.assertEquals;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import timber.log.Timber;
+
+@RunWith(AndroidJUnit4.class)
+public class TimberLoggingTest {
+
+    @Rule
+    public TimberLoggingRule timberLoggingRule = new TimberLoggingRule();
+
+    private TestTree testTree;
+
+    @Before
+    public void setUp() throws Exception {
+        testTree = new TestTree();
+        Timber.plant(testTree);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+       testTree = null;
+    }
+
+    @Test
+    public void timberTagIsLaunchDarklySdkForAllEvents() {
+        LDConfig.log().d("event");
+        LDConfig.log().d("event");
+
+        assertEquals(List.of("LaunchDarklySdk", "LaunchDarklySdk"), testTree.loggedTags);
+    }
+
+    private static class TestTree extends Timber.Tree {
+
+        final List<String> loggedTags = new ArrayList<String>();
+
+        @Override
+        protected void log(int priority, @Nullable String tag, @NonNull String message, @Nullable Throwable t) {
+            loggedTags.add(tag);
+        }
+    }
+}

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ConnectivityManager.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ConnectivityManager.java
@@ -112,7 +112,7 @@ class ConnectivityManager {
                         LDClient ldClient = LDClient.getForMobileKey(environmentName);
                         ldClient.updateListenersOnFailure(connectionInformation.getLastFailure());
                     } catch (LaunchDarklyException ex) {
-                        LDConfig.LOG.e(e, "Error getting LDClient for ConnectivityManager");
+                        LDConfig.log().e(e, "Error getting LDClient for ConnectivityManager");
                     }
                     callInitCallback();
                 }
@@ -374,13 +374,13 @@ class ConnectivityManager {
         try {
             saveConnectionInformation();
         } catch (Exception ex) {
-            LDConfig.LOG.w(ex, "Error saving connection information");
+            LDConfig.log().w(ex, "Error saving connection information");
         }
         try {
             LDClient ldClient = LDClient.getForMobileKey(environmentName);
             ldClient.updateListenersConnectionModeChanged(connectionInformation);
         } catch (LaunchDarklyException e) {
-            LDConfig.LOG.e(e, "Error getting LDClient for ConnectivityManager");
+            LDConfig.log().e(e, "Error getting LDClient for ConnectivityManager");
         }
     }
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/DefaultEventProcessor.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/DefaultEventProcessor.java
@@ -149,12 +149,12 @@ class DefaultEventProcessor implements EventProcessor, Closeable {
             baseHeadersForRequest.put("X-LaunchDarkly-Payload-ID", eventPayloadId);
             baseHeadersForRequest.putAll(baseEventHeaders);
 
-            LDConfig.LOG.d("Posting %s event(s) to %s", events.size(), url);
-            LDConfig.LOG.d("Events body: %s", content);
+            LDConfig.log().d("Posting %s event(s) to %s", events.size(), url);
+            LDConfig.log().d("Events body: %s", content);
 
             for (int attempt = 0; attempt < 2; attempt++) {
                 if (attempt > 0) {
-                    LDConfig.LOG.w("Will retry posting events after 1 second");
+                    LDConfig.log().w("Will retry posting events after 1 second");
                     try {
                         Thread.sleep(1000);
                     } catch (InterruptedException e) {}
@@ -166,11 +166,11 @@ class DefaultEventProcessor implements EventProcessor, Closeable {
                         .build();
 
                 try (Response response = client.newCall(request).execute()) {
-                    LDConfig.LOG.d("Events Response: %s", response.code());
-                    LDConfig.LOG.d("Events Response Date: %s", response.header("Date"));
+                    LDConfig.log().d("Events Response: %s", response.code());
+                    LDConfig.log().d("Events Response Date: %s", response.header("Date"));
 
                     if (!response.isSuccessful()) {
-                        LDConfig.LOG.w("Unexpected response status when posting events: %d", response.code());
+                        LDConfig.log().w("Unexpected response status when posting events: %d", response.code());
                         if (isHttpErrorRecoverable(response.code())) {
                             continue;
                         }
@@ -179,7 +179,7 @@ class DefaultEventProcessor implements EventProcessor, Closeable {
                     tryUpdateDate(response);
                     break;
                 } catch (IOException e) {
-                    LDConfig.LOG.e(e, "Unhandled exception in LaunchDarkly client attempting to connect to URI: %s", request.url());
+                    LDConfig.log().e(e, "Unhandled exception in LaunchDarkly client attempting to connect to URI: %s", request.url());
                 }
             }
         }
@@ -192,7 +192,7 @@ class DefaultEventProcessor implements EventProcessor, Closeable {
                     Date date = sdf.parse(dateString);
                     currentTimeMs = date.getTime();
                 } catch (ParseException pe) {
-                    LDConfig.LOG.e(pe, "Failed to parse date header");
+                    LDConfig.log().e(pe, "Failed to parse date header");
                 }
             }
         }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/DefaultUserManager.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/DefaultUserManager.java
@@ -80,7 +80,7 @@ class DefaultUserManager implements UserManager {
      */
     void setCurrentUser(final LDUser user) {
         String userBase64 = base64Url(user);
-        LDConfig.LOG.d("Setting current user to: [%s] [%s]", userBase64, userBase64ToJson(userBase64));
+        LDConfig.log().d("Setting current user to: [%s] [%s]", userBase64, userBase64ToJson(userBase64));
         currentUser = user;
         flagStoreManager.switchToUser(DefaultUserManager.sharedPrefs(user));
     }
@@ -98,7 +98,7 @@ class DefaultUserManager implements UserManager {
             @Override
             public void onError(Throwable e) {
                 if (LDUtil.isClientConnected(application, environmentName)) {
-                    LDConfig.LOG.e(e, "Error when attempting to set user: [%s] [%s]",
+                    LDConfig.log().e(e, "Error when attempting to set user: [%s] [%s]",
                             base64Url(currentUser),
                             userBase64ToJson(base64Url(currentUser)));
                 }
@@ -133,14 +133,14 @@ class DefaultUserManager implements UserManager {
      */
     @SuppressWarnings("JavaDoc")
     private void saveFlagSettings(JsonObject flagsJson, LDUtil.ResultCallback<Void> onCompleteListener) {
-        LDConfig.LOG.d("saveFlagSettings for user key: %s", currentUser.getKey());
+        LDConfig.log().d("saveFlagSettings for user key: %s", currentUser.getKey());
 
         try {
             final List<Flag> flags = GsonCache.getGson().fromJson(flagsJson, FlagsResponse.class).getFlags();
             flagStoreManager.getCurrentUserStore().clearAndApplyFlagUpdates(flags);
             onCompleteListener.onSuccess(null);
         } catch (Exception e) {
-            LDConfig.LOG.d("Invalid JsonObject for flagSettings: %s", flagsJson);
+            LDConfig.log().d("Invalid JsonObject for flagSettings: %s", flagsJson);
             onCompleteListener.onError(new LDFailure("Invalid Json received from flags endpoint", e, LDFailure.FailureType.INVALID_RESPONSE_BODY));
         }
     }
@@ -157,13 +157,13 @@ class DefaultUserManager implements UserManager {
                     flagStoreManager.getCurrentUserStore().applyFlagUpdate(deleteFlagResponse);
                     onCompleteListener.onSuccess(null);
                 } else {
-                    LDConfig.LOG.d("Invalid DELETE payload: %s", json);
+                    LDConfig.log().d("Invalid DELETE payload: %s", json);
                     onCompleteListener.onError(new LDFailure("Invalid DELETE payload",
                             LDFailure.FailureType.INVALID_RESPONSE_BODY));
                 }
             });
         } catch (Exception ex) {
-            LDConfig.LOG.d(ex, "Invalid DELETE payload: %s", json);
+            LDConfig.log().d(ex, "Invalid DELETE payload: %s", json);
             onCompleteListener.onError(new LDFailure("Invalid DELETE payload", ex,
                     LDFailure.FailureType.INVALID_RESPONSE_BODY));
         }
@@ -173,12 +173,12 @@ class DefaultUserManager implements UserManager {
         try {
             final List<Flag> flags = GsonCache.getGson().fromJson(json, FlagsResponse.class).getFlags();
             executor.submit(() -> {
-                LDConfig.LOG.d("PUT for user key: %s", currentUser.getKey());
+                LDConfig.log().d("PUT for user key: %s", currentUser.getKey());
                 flagStoreManager.getCurrentUserStore().clearAndApplyFlagUpdates(flags);
                 onCompleteListener.onSuccess(null);
             });
         } catch (Exception ex) {
-            LDConfig.LOG.d(ex, "Invalid PUT payload: %s", json);
+            LDConfig.log().d(ex, "Invalid PUT payload: %s", json);
             onCompleteListener.onError(new LDFailure("Invalid PUT payload", ex,
                     LDFailure.FailureType.INVALID_RESPONSE_BODY));
         }
@@ -192,13 +192,13 @@ class DefaultUserManager implements UserManager {
                     flagStoreManager.getCurrentUserStore().applyFlagUpdate(flag);
                     onCompleteListener.onSuccess(null);
                 } else {
-                    LDConfig.LOG.d("Invalid PATCH payload: %s", json);
+                    LDConfig.log().d("Invalid PATCH payload: %s", json);
                     onCompleteListener.onError(new LDFailure("Invalid PATCH payload",
                             LDFailure.FailureType.INVALID_RESPONSE_BODY));
                 }
             });
         } catch (Exception ex) {
-            LDConfig.LOG.d(ex, "Invalid PATCH payload: %s", json);
+            LDConfig.log().d(ex, "Invalid PATCH payload: %s", json);
             onCompleteListener.onError(new LDFailure("Invalid PATCH payload", ex,
                     LDFailure.FailureType.INVALID_RESPONSE_BODY));
         }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/DiagnosticEventProcessor.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/DiagnosticEventProcessor.java
@@ -126,13 +126,13 @@ class DiagnosticEventProcessor {
                 .headers(config.headersForEnvironment(environment, baseDiagnosticHeaders))
                 .post(RequestBody.create(content, JSON)).build();
 
-        LDConfig.LOG.d("Posting diagnostic event to %s with body %s", request.url(), content);
+        LDConfig.log().d("Posting diagnostic event to %s with body %s", request.url(), content);
 
         try (Response response = client.newCall(request).execute()) {
-            LDConfig.LOG.d("Diagnostic Event Response: %s", response.code());
-            LDConfig.LOG.d("Diagnostic Event Response Date: %s", response.header("Date"));
+            LDConfig.log().d("Diagnostic Event Response: %s", response.code());
+            LDConfig.log().d("Diagnostic Event Response Date: %s", response.header("Date"));
         } catch (IOException e) {
-            LDConfig.LOG.w(e, "Unhandled exception in LaunchDarkly client attempting to connect to URI: %s", request.url());
+            LDConfig.log().w(e, "Unhandled exception in LaunchDarkly client attempting to connect to URI: %s", request.url());
         }
     }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/DiagnosticStore.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/DiagnosticStore.java
@@ -81,7 +81,7 @@ class DiagnosticStore {
             DiagnosticEvent.StreamInit[] streamInitsArr = GsonCache.getGson().fromJson(streamInitsString, DiagnosticEvent.StreamInit[].class);
             streamInits = Arrays.asList(streamInitsArr);
         } catch (Exception ex) {
-            LDConfig.LOG.w(ex, "Invalid stream inits array in diagnostic data store");
+            LDConfig.log().w(ex, "Invalid stream inits array in diagnostic data store");
             streamInits = null;
         }
         return streamInits;

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/Foreground.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/Foreground.java
@@ -148,17 +148,17 @@ class Foreground implements Application.ActivityLifecycleCallbacks {
 
         if (wasBackground) {
             handler.post(() -> {
-                LDConfig.LOG.d("went foreground");
+                LDConfig.log().d("went foreground");
                 for (Listener l : listeners) {
                     try {
                         l.onBecameForeground();
                     } catch (Exception exc) {
-                        LDConfig.LOG.e(exc, "Listener threw exception!");
+                        LDConfig.log().e(exc, "Listener threw exception!");
                     }
                 }
             });
         } else {
-            LDConfig.LOG.d("still foreground");
+            LDConfig.log().d("still foreground");
         }
     }
 
@@ -174,16 +174,16 @@ class Foreground implements Application.ActivityLifecycleCallbacks {
         handler.postDelayed(check = () -> {
             if (foreground && paused) {
                 foreground = false;
-                LDConfig.LOG.d("went background");
+                LDConfig.log().d("went background");
                 for (Listener l : listeners) {
                     try {
                         l.onBecameBackground();
                     } catch (Exception exc) {
-                        LDConfig.LOG.e(exc, "Listener threw exception!");
+                        LDConfig.log().e(exc, "Listener threw exception!");
                     }
                 }
             } else {
-                LDConfig.LOG.d("still background");
+                LDConfig.log().d("still background");
             }
         }, CHECK_DELAY);
     }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/HttpFeatureFlagFetcher.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/HttpFeatureFlagFetcher.java
@@ -45,7 +45,7 @@ class HttpFeatureFlagFetcher implements FeatureFetcher {
         this.context = context;
 
         File cacheDir = new File(context.getCacheDir(), "com.launchdarkly.http-cache");
-        LDConfig.LOG.d("Using cache at: %s", cacheDir.getAbsolutePath());
+        LDConfig.log().d("Using cache at: %s", cacheDir.getAbsolutePath());
 
         client = new OkHttpClient.Builder()
                 .cache(new Cache(cacheDir, MAX_CACHE_SIZE_BYTES))
@@ -62,12 +62,12 @@ class HttpFeatureFlagFetcher implements FeatureFetcher {
                     ? getReportRequest(user)
                     : getDefaultRequest(user);
 
-            LDConfig.LOG.d(request.toString());
+            LDConfig.log().d(request.toString());
             Call call = client.newCall(request);
             call.enqueue(new Callback() {
                 @Override
                 public void onFailure(@NonNull Call call, @NonNull IOException e) {
-                    LDConfig.LOG.e(e, "Exception when fetching flags.");
+                    LDConfig.log().e(e, "Exception when fetching flags.");
                     callback.onError(new LDFailure("Exception while fetching flags", e, LDFailure.FailureType.NETWORK_FAILURE));
                 }
 
@@ -81,20 +81,20 @@ class HttpFeatureFlagFetcher implements FeatureFetcher {
                         }
                         if (!response.isSuccessful()) {
                             if (response.code() == 400) {
-                                LDConfig.LOG.e("Received 400 response when fetching flag values. Please check recommended ProGuard settings");
+                                LDConfig.log().e("Received 400 response when fetching flag values. Please check recommended ProGuard settings");
                             }
                             callback.onError(new LDInvalidResponseCodeFailure("Unexpected response when retrieving Feature Flags: " + response + " using url: "
                                     + request.url() + " with body: " + body, response.code(), true));
                         }
-                        LDConfig.LOG.d(body);
-                        LDConfig.LOG.d("Cache hit count: %s Cache network Count: %s", client.cache().hitCount(), client.cache().networkCount());
-                        LDConfig.LOG.d("Cache response: %s", response.cacheResponse());
-                        LDConfig.LOG.d("Network response: %s", response.networkResponse());
+                        LDConfig.log().d(body);
+                        LDConfig.log().d("Cache hit count: %s Cache network Count: %s", client.cache().hitCount(), client.cache().networkCount());
+                        LDConfig.log().d("Cache response: %s", response.cacheResponse());
+                        LDConfig.log().d("Network response: %s", response.networkResponse());
 
                         JsonObject jsonObject = JsonParser.parseString(body).getAsJsonObject();
                         callback.onSuccess(jsonObject);
                     } catch (Exception e) {
-                        LDConfig.LOG.e(e, "Exception when handling response for url: %s with body: %s", request.url(), body);
+                        LDConfig.log().e(e, "Exception when handling response for url: %s with body: %s", request.url(), body);
                         callback.onError(new LDFailure("Exception while handling flag fetch response", e, LDFailure.FailureType.INVALID_RESPONSE_BODY));
                     } finally {
                         if (response != null) {
@@ -111,7 +111,7 @@ class HttpFeatureFlagFetcher implements FeatureFetcher {
         if (config.isEvaluationReasons()) {
             uri += "?withReasons=true";
         }
-        LDConfig.LOG.d("Attempting to fetch Feature flags using uri: %s", uri);
+        LDConfig.log().d("Attempting to fetch Feature flags using uri: %s", uri);
         return new Request.Builder().url(uri)
                 .headers(config.headersForEnvironment(environmentName, null))
                 .build();
@@ -122,7 +122,7 @@ class HttpFeatureFlagFetcher implements FeatureFetcher {
         if (config.isEvaluationReasons()) {
             reportUri += "?withReasons=true";
         }
-        LDConfig.LOG.d("Attempting to report user using uri: %s", reportUri);
+        LDConfig.log().d("Attempting to report user using uri: %s", reportUri);
         String userJson = GSON.toJson(user);
         RequestBody reportBody = RequestBody.create(userJson, JSON);
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDConfig.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDConfig.java
@@ -28,7 +28,6 @@ import timber.log.Timber.Tree;
 public class LDConfig {
 
     static final String TIMBER_TAG = "LaunchDarklySdk";
-    static final Tree LOG = Timber.tag(TIMBER_TAG);
     static final String SHARED_PREFS_BASE_KEY = "LaunchDarkly-";
     static final String USER_AGENT_HEADER_VALUE = "AndroidClient/" + BuildConfig.VERSION_NAME;
     static final String AUTH_SCHEME = "api_key ";
@@ -691,24 +690,24 @@ public class LDConfig {
         public LDConfig build() {
             if (!stream) {
                 if (pollingIntervalMillis < MIN_POLLING_INTERVAL_MILLIS) {
-                    LDConfig.LOG.w("setPollingIntervalMillis: %s was set below the allowed minimum of: %s. Ignoring and using minimum value.", pollingIntervalMillis, MIN_POLLING_INTERVAL_MILLIS);
+                    LDConfig.log().w("setPollingIntervalMillis: %s was set below the allowed minimum of: %s. Ignoring and using minimum value.", pollingIntervalMillis, MIN_POLLING_INTERVAL_MILLIS);
                     pollingIntervalMillis = MIN_POLLING_INTERVAL_MILLIS;
                 }
 
                 if (!disableBackgroundUpdating && backgroundPollingIntervalMillis < pollingIntervalMillis) {
-                    LDConfig.LOG.w("BackgroundPollingIntervalMillis: %s was set below the foreground polling interval: %s. Ignoring and using minimum value for background polling.", backgroundPollingIntervalMillis, pollingIntervalMillis);
+                    LDConfig.log().w("BackgroundPollingIntervalMillis: %s was set below the foreground polling interval: %s. Ignoring and using minimum value for background polling.", backgroundPollingIntervalMillis, pollingIntervalMillis);
                     backgroundPollingIntervalMillis = MIN_BACKGROUND_POLLING_INTERVAL_MILLIS;
                 }
 
                 if (eventsFlushIntervalMillis == 0) {
                     eventsFlushIntervalMillis = pollingIntervalMillis;
-                    LDConfig.LOG.d("Streaming is disabled, so we're setting the events flush interval to the polling interval value: %s", pollingIntervalMillis);
+                    LDConfig.log().d("Streaming is disabled, so we're setting the events flush interval to the polling interval value: %s", pollingIntervalMillis);
                 }
             }
 
             if (!disableBackgroundUpdating) {
                 if (backgroundPollingIntervalMillis < MIN_BACKGROUND_POLLING_INTERVAL_MILLIS) {
-                    LDConfig.LOG.w("BackgroundPollingIntervalMillis: %s was set below the minimum allowed: %s. Ignoring and using minimum value.", backgroundPollingIntervalMillis, MIN_BACKGROUND_POLLING_INTERVAL_MILLIS);
+                    LDConfig.log().w("BackgroundPollingIntervalMillis: %s was set below the minimum allowed: %s. Ignoring and using minimum value.", backgroundPollingIntervalMillis, MIN_BACKGROUND_POLLING_INTERVAL_MILLIS);
                     backgroundPollingIntervalMillis = MIN_BACKGROUND_POLLING_INTERVAL_MILLIS;
                 }
             }
@@ -718,7 +717,7 @@ public class LDConfig {
             }
 
             if (diagnosticRecordingIntervalMillis < MIN_DIAGNOSTIC_RECORDING_INTERVAL_MILLIS) {
-                LDConfig.LOG.w("diagnosticRecordingIntervalMillis was set to %s, lower than the minimum allowed (%s). Ignoring and using minimum value.", diagnosticRecordingIntervalMillis, MIN_DIAGNOSTIC_RECORDING_INTERVAL_MILLIS);
+                LDConfig.log().w("diagnosticRecordingIntervalMillis was set to %s, lower than the minimum allowed (%s). Ignoring and using minimum value.", diagnosticRecordingIntervalMillis, MIN_DIAGNOSTIC_RECORDING_INTERVAL_MILLIS);
                 diagnosticRecordingIntervalMillis = MIN_DIAGNOSTIC_RECORDING_INTERVAL_MILLIS;
             }
 
@@ -757,5 +756,9 @@ public class LDConfig {
                     headerTransform,
                     autoAliasingOptOut);
         }
+    }
+
+    public static final Tree log() {
+        return Timber.tag(TIMBER_TAG);
     }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDFutures.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDFutures.java
@@ -90,7 +90,7 @@ class LDAwaitFuture<T> implements Future<T> {
                 notifier.notifyAll();
             }
         } else {
-            LDConfig.LOG.w("LDAwaitFuture set twice");
+            LDConfig.log().w("LDAwaitFuture set twice");
         }
     }
 
@@ -102,7 +102,7 @@ class LDAwaitFuture<T> implements Future<T> {
                 notifier.notifyAll();
             }
         } else {
-            LDConfig.LOG.w("LDAwaitFuture set twice");
+            LDConfig.log().w("LDAwaitFuture set twice");
         }
     }
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDUtil.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDUtil.java
@@ -75,7 +75,7 @@ class LDUtil {
         try {
             return deviceConnected && !LDClient.getForMobileKey(environmentName).isOffline();
         } catch (LaunchDarklyException e) {
-            LDConfig.LOG.e(e, "Exception caught when getting LDClient");
+            LDConfig.log().e(e, "Exception caught when getting LDClient");
             return false;
         }
     }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/Migration.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/Migration.java
@@ -29,7 +29,7 @@ class Migration {
             try {
                 migrate_2_7_fresh(application, config);
             } catch (Exception ex) {
-                LDConfig.LOG.w(ex, "Exception while performing fresh v2.7.0 store migration");
+                LDConfig.log().w(ex, "Exception while performing fresh v2.7.0 store migration");
             }
         }
 
@@ -37,7 +37,7 @@ class Migration {
             try {
                 migrate_2_7_from_2_6(application);
             } catch (Exception ex) {
-                LDConfig.LOG.w(ex, "Exception while performing v2.6.0 to v2.7.0 store migration");
+                LDConfig.log().w(ex, "Exception while performing v2.6.0 to v2.7.0 store migration");
             }
         }
     }
@@ -62,7 +62,7 @@ class Migration {
     }
 
     private static void migrate_2_7_fresh(Application application, LDConfig config) {
-        LDConfig.LOG.d("Migrating to v2.7.0 shared preferences store");
+        LDConfig.log().d("Migrating to v2.7.0 shared preferences store");
 
         ArrayList<String> userKeys = getUserKeysPre_2_6(application, config);
         SharedPreferences versionSharedPrefs = application.getSharedPreferences(LDConfig.SHARED_PREFS_BASE_KEY + "version", Context.MODE_PRIVATE);
@@ -92,7 +92,7 @@ class Migration {
         }
 
         if (allSuccess) {
-            LDConfig.LOG.d("Migration to v2.7.0 shared preferences store successful");
+            LDConfig.log().d("Migration to v2.7.0 shared preferences store successful");
             SharedPreferences migrations = application.getSharedPreferences(LDConfig.SHARED_PREFS_BASE_KEY + "migrations", Context.MODE_PRIVATE);
             boolean logged = migrations.edit().putString("v2.7.0", "v2.7.0").commit();
             if (logged) {
@@ -108,7 +108,7 @@ class Migration {
     }
 
     private static void migrate_2_7_from_2_6(Application application) {
-        LDConfig.LOG.d("Migrating to v2.7.0 shared preferences store from v2.6.0");
+        LDConfig.log().d("Migrating to v2.7.0 shared preferences store from v2.6.0");
 
         Map<String, Set<String>> keyUsers = getUserKeys_2_6(application);
 
@@ -133,7 +133,7 @@ class Migration {
         }
 
         if (allSuccess) {
-            LDConfig.LOG.d("Migration to v2.7.0 shared preferences store successful");
+            LDConfig.log().d("Migration to v2.7.0 shared preferences store successful");
             SharedPreferences migrations = application.getSharedPreferences(LDConfig.SHARED_PREFS_BASE_KEY + "migrations", Context.MODE_PRIVATE);
             boolean logged = migrations.edit().putString("v2.7.0", "v2.7.0").commit();
             if (logged) {

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/PollingUpdater.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/PollingUpdater.java
@@ -27,13 +27,13 @@ public class PollingUpdater extends BroadcastReceiver {
     }
 
     synchronized static void startBackgroundPolling(Context context) {
-        LDConfig.LOG.d("Starting background polling");
+        LDConfig.log().d("Starting background polling");
         startPolling(context, backgroundPollingIntervalMillis, backgroundPollingIntervalMillis);
     }
 
     synchronized static void startPolling(Context context, int initialDelayMillis, int intervalMillis) {
         stop(context);
-        LDConfig.LOG.d("startPolling with initialDelayMillis: %d and intervalMillis: %d", initialDelayMillis, intervalMillis);
+        LDConfig.log().d("startPolling with initialDelayMillis: %d and intervalMillis: %d", initialDelayMillis, intervalMillis);
         PendingIntent pendingIntent = getPendingIntent(context);
         AlarmManager alarmMgr = getAlarmManager(context);
 
@@ -44,12 +44,12 @@ public class PollingUpdater extends BroadcastReceiver {
                     intervalMillis,
                     pendingIntent);
         } catch (Exception ex) {
-            LDConfig.LOG.w(ex, "Exception occurred when creating [background] polling alarm, likely due to the host application having too many existing alarms.");
+            LDConfig.log().w(ex, "Exception occurred when creating [background] polling alarm, likely due to the host application having too many existing alarms.");
         }
     }
 
     synchronized static void stop(Context context) {
-        LDConfig.LOG.d("Stopping pollingUpdater");
+        LDConfig.log().d("Stopping pollingUpdater");
         PendingIntent pendingIntent = getPendingIntent(context);
         AlarmManager alarmMgr = getAlarmManager(context);
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPrefsFlagStore.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPrefsFlagStore.java
@@ -44,7 +44,7 @@ class SharedPrefsFlagStore implements FlagStore {
         sharedPreferences = null;
 
         File file = new File(application.getFilesDir().getParent() + "/shared_prefs/" + prefsKey + ".xml");
-        LDConfig.LOG.i("Deleting SharedPrefs file:%s", file.getAbsolutePath());
+        LDConfig.log().i("Deleting SharedPrefs file:%s", file.getAbsolutePath());
 
         //noinspection ResultOfMethodCallIgnored
         file.delete();

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPrefsFlagStoreManager.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPrefsFlagStoreManager.java
@@ -73,7 +73,7 @@ class SharedPrefsFlagStoreManager implements FlagStoreManager, StoreUpdatedListe
             // Remove oldest users until we are at MAX_USERS.
             for (int i = 0; i < usersToRemove; i++) {
                 String removed = oldestFirstUsers.next();
-                LDConfig.LOG.d("Exceeded max # of users: [%s] Removing user: [%s]", maxCachedUsers, removed);
+                LDConfig.log().d("Exceeded max # of users: [%s] Removing user: [%s]", maxCachedUsers, removed);
                 // Load FlagStore for oldest user and delete it.
                 flagStoreFactory.createFlagStore(storeIdentifierForUser(removed)).delete();
                 // Remove entry from usersSharedPrefs.
@@ -99,9 +99,9 @@ class SharedPrefsFlagStoreManager implements FlagStoreManager, StoreUpdatedListe
         Set<FeatureFlagChangeListener> oldSet = listeners.putIfAbsent(key, newSet);
         if (oldSet != null) {
             oldSet.add(listener);
-            LDConfig.LOG.d("Added listener. Total count: [%s]", oldSet.size());
+            LDConfig.log().d("Added listener. Total count: [%s]", oldSet.size());
         } else {
-            LDConfig.LOG.d("Added listener. Total count: 1");
+            LDConfig.log().d("Added listener. Total count: 1");
         }
     }
 
@@ -111,7 +111,7 @@ class SharedPrefsFlagStoreManager implements FlagStoreManager, StoreUpdatedListe
         if (keySet != null) {
             boolean removed = keySet.remove(listener);
             if (removed) {
-                LDConfig.LOG.d("Removing listener for key: [%s]", key);
+                LDConfig.log().d("Removing listener for key: [%s]", key);
             }
         }
     }
@@ -135,9 +135,9 @@ class SharedPrefsFlagStoreManager implements FlagStoreManager, StoreUpdatedListe
         for (String k : all.keySet()) {
             try {
                 sortedMap.put((Long) all.get(k), k);
-                LDConfig.LOG.d("Found user: %s", userAndTimeStampToHumanReadableString(k, (Long) all.get(k)));
+                LDConfig.log().d("Found user: %s", userAndTimeStampToHumanReadableString(k, (Long) all.get(k)));
             } catch (ClassCastException cce) {
-                LDConfig.LOG.e(cce, "Unexpected type! This is not good");
+                LDConfig.log().e(cce, "Unexpected type! This is not good");
             }
         }
         return sortedMap.values();

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPrefsSummaryEventStore.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPrefsSummaryEventStore.java
@@ -49,7 +49,7 @@ class SharedPrefsSummaryEventStore implements SummaryEventStore {
         }
         editor.apply();
 
-        LDConfig.LOG.d("Updated summary for flagKey %s to %s", flagResponseKey, GsonCache.getGson().toJson(storedCounters));
+        LDConfig.log().d("Updated summary for flagKey %s to %s", flagResponseKey, GsonCache.getGson().toJson(storedCounters));
     }
 
     @Override


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

#17 #38 #113 #147 #173  

**Describe the solution you've provided**

All Timber events should have one common TAG - `LaunchDarklySdk`

**Describe alternatives you've considered**

Just fixing a bug.

**Additional context**

`Timber.tag(<..>)` had to be called before logging each event. Previous implementation called `tag()` once per app lifecycle.
