### PR TITLE
prepare 4.2.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Refer to the [SDK documentation](https://docs.launchdarkly.com/sdk/client-side/a
 
 ## Learn more
 
-Check out our [documentation](https://docs.launchdarkly.com) for in-depth instructions on configuring and using LaunchDarkly. You can also head straight to the [complete reference guide for this SDK](https://docs.launchdarkly.com/docs/android-sdk-reference) or our [Javadocs](http://launchdarkly.github.io/android-client-sdk/).
+Check out our [documentation](https://docs.launchdarkly.com) for in-depth instructions on configuring and using LaunchDarkly. You can also head straight to the [complete reference guide for this SDK](https://docs.launchdarkly.com/sdk/client-side/android) or our [Javadocs](http://launchdarkly.github.io/android-client-sdk/).
 
 ## Testing
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/StreamingDataSource.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/StreamingDataSource.java
@@ -2,6 +2,7 @@ package com.launchdarkly.sdk.android;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.launchdarkly.eventsource.EventHandler;
 import com.launchdarkly.eventsource.EventSource;
@@ -202,7 +203,8 @@ final class StreamingDataSource implements DataSource {
         return uri;
     }
 
-    private void handle(final String name, final String eventData,
+    @VisibleForTesting
+    void handle(final String name, final String eventData,
                         @NonNull final Callback<Boolean> resultCallback) {
         switch (name.toLowerCase()) {
             case PUT:
@@ -226,7 +228,7 @@ final class StreamingDataSource implements DataSource {
                 break;
             case PING:
                 ConnectivityManager.fetchAndSetData(fetcher, currentContext, dataSourceUpdateSink,
-                        LDUtil.noOpCallback(), logger);
+                        resultCallback, logger);
                 break;
             default:
                 logger.debug("Found an unknown stream protocol: {}", name);


### PR DESCRIPTION
## [4.2.3] - 2023-06-06
### Fixed:
- Streaming data connection to a relax proxy now calls the callback correctly after fetching the flag data.
- Flag listeners are now called correctly after `identify` results in flag value changes.