### PR TITLE
ci: removing hardcode dry_run

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,6 +31,5 @@ jobs:
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     with:
       run_tests: true
-#      TODO: revert dry run put in place during testing
-      dry_run: true
+      dry_run: false
       prerelease: false


### PR DESCRIPTION
This dry_run was hardcoded as a final protection against accidental publish during development.