### PR TITLE
ci: fixing publish script variable visibility

### DIFF
--- a/.github/actions/publish/action.yml
+++ b/.github/actions/publish/action.yml
@@ -1,14 +1,26 @@
 name: Publish Package
 description: 'Publish the package to Sonatype'
 inputs:
-  code_signing_keyring:
-    description: 'The path of the code signing keyring.'
+  dry_run:
+    description: 'Is this a dry run. If so no package will be published.'
     required: true
   prerelease:
     description: 'Is this a prerelease. If so then it will be published to the staging repository only.'
     required: true
-  dry_run:
-    description: 'Is this a dry run. If so no package will be published.'
+  signing_key_id:
+    description: 'Signing key ID'
+    required: true
+  signing_key_passphrase:
+    description: 'Signing key passphrase'
+    required: true
+  code_signing_keyring:
+    description: 'The path of the code signing keyring.'
+    required: true
+  sonatype_username:
+    description: 'Sonatype repo username.'
+    required: true
+  sonatype_password:
+    description: 'Sonatype repo password.'
     required: true
 
 runs:
@@ -19,7 +31,11 @@ runs:
       if: ${{ inputs.dry_run == 'false' }}
       env:
         LD_RELEASE_IS_PRERELEASE: ${{ inputs.prerelease }}
+        SIGNING_KEY_ID: $${ inputs.signing_key_id }}
+        SIGNING_KEY_PASSPHRASE: $${ inputs.signing_key_passphrase }}
         SIGNING_SECRET_KEY_RING_FILE: ${{ inputs.code_signing_keyring }}
+        SONATYPE_USER_NAME: ${{ inputs.sonatype_username }}
+        SONATYPE_PASSWORD: ${{ inputs.sonatype_password }}
       run: source $GITHUB_ACTION_PATH/publish.sh
 
     - name: Dry Run Publish Library

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,8 +51,8 @@ jobs:
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
           ssm_parameter_pairs: '/production/common/releasing/sonatype/username = SONATYPE_USER_NAME,
-          /production/common/releasing/sonatype/password = SONATYPE_PASSWORD
-          /production/common/releasing/android_code_signing/private_key_id = SIGNING_KEY_ID
+          /production/common/releasing/sonatype/password = SONATYPE_PASSWORD,
+          /production/common/releasing/android_code_signing/private_key_id = SIGNING_KEY_ID,
           /production/common/releasing/android_code_signing/private_key_passphrase = SIGNING_KEY_PASSPHRASE'
           s3_path_pairs: 'launchdarkly-releaser/android/code-signing-keyring.gpg = code-signing-keyring.gpg'
 
@@ -61,7 +61,11 @@ jobs:
         with:
           dry_run: ${{ inputs.dry_run }}
           prerelease: ${{ inputs.prerelease }}
+          signing_key_id: ${{ env.SIGNING_KEY_ID }}
+          signing_key_passphrase: ${{ env.SIGNING_KEY_PASSPHRASE }}
           code_signing_keyring: 'code-signing-keyring.gpg'
+          sonatype_username: ${{ env.SONATYPE_USER_NAME }}
+          sonatype_password: ${{ env.SONATYPE_PASSWORD }}
 
       - name: Publish Documentation
         uses: ./.github/actions/publish-docs


### PR DESCRIPTION
Variables used in publish.sh were not in scope.  This change also makes the action a little more reusable.