### PR TITLE
ci: enabling ci tests after fixing test race condition

### DIFF
--- a/.github/actions/ci/action.yml
+++ b/.github/actions/ci/action.yml
@@ -33,27 +33,27 @@ runs:
       id: build
       run: ./gradlew build jar
 
-#    - name: Run Unit Tests
-#      if: inputs.run_tests == 'true'
-#      shell: bash
-#      run: ./gradlew test
-#
-#    - name: Build contract tests
-#      shell: bash
-#      run: make build-contract-tests
-#
-#    - name: Perform Instrumented Tests
-#      uses: reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 #2.30.1
-#      with:
-#        api-level: ${{ inputs.android_api_level }}
-#        target: google_apis
-#        emulator-boot-timeout: 900
-#        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-#        disable-animations: true
-#        script: |
-#          make start-contract-test-service
-#          make run-contract-tests
-#          ./gradlew connectedDebugAndroidTest
+    - name: Run Unit Tests
+      if: inputs.run_tests == 'true'
+      shell: bash
+      run: ./gradlew test
+
+    - name: Build contract tests
+      shell: bash
+      run: make build-contract-tests
+
+    - name: Perform Instrumented Tests
+      uses: reactivecircus/android-emulator-runner@6b0df4b0efb23bb0ec63d881db79aefbc976e4b2 #2.30.1
+      with:
+        api-level: ${{ inputs.android_api_level }}
+        target: google_apis
+        emulator-boot-timeout: 900
+        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+        disable-animations: true
+        script: |
+          make start-contract-test-service
+          make run-contract-tests
+          ./gradlew connectedDebugAndroidTest
 
     - name: Build documentation
       uses: ./.github/actions/build-docs

--- a/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientEventTest.java
+++ b/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientEventTest.java
@@ -257,21 +257,16 @@ public class LDClientEventTest {
                     .diagnosticOptOut(true)
                     .serviceEndpoints(Components.serviceEndpoints()
                             .events(baseUrl.uri())
-                            .streaming(baseUrl.uri())
-                            .polling(baseUrl.uri())
                     )
                     .build();
 
-            // Don't wait as we are not set offline
             try (LDClient ldClient = LDClient.init(application, ldConfig, ldContext, 0)){
-                ldClient.track("test-event");
                 ldClient.blockingFlush();
 
-                LDValue[] events = getEventsFromLastRequest(mockEventsServer, 2);
-                LDValue identifyEvent = events[0], customEvent = events[1];
-                assertIdentifyEvent(identifyEvent, ldContext);
-                assertTrue(customEvent.get("contextKeys").toString().contains("ld_application"));
-                assertTrue(customEvent.get("contextKeys").toString().contains("ld_device"));
+                LDValue[] events = getEventsFromLastRequest(mockEventsServer, 1);
+                LDValue identifyEvent = events[0];
+                assertTrue(identifyEvent.get("context").toString().contains("ld_application"));
+                assertTrue(identifyEvent.get("context").toString().contains("ld_device"));
             }
         }
     }
@@ -289,21 +284,16 @@ public class LDClientEventTest {
                     .diagnosticOptOut(true)
                     .serviceEndpoints(Components.serviceEndpoints()
                             .events(baseUrl.uri())
-                            .streaming(baseUrl.uri())
-                            .polling(baseUrl.uri())
                     )
                     .build();
 
-            // Don't wait as we are not set offline
             try (LDClient ldClient = LDClient.init(application, ldConfig, ldContext, 0)){
-                ldClient.track("test-event");
                 ldClient.blockingFlush();
 
-                LDValue[] events = getEventsFromLastRequest(mockEventsServer, 2);
-                LDValue identifyEvent = events[0], customEvent = events[1];
-                assertIdentifyEvent(identifyEvent, ldContext);
-                assertFalse(customEvent.get("contextKeys").toString().contains("ld_application"));
-                assertFalse(customEvent.get("contextKeys").toString().contains("ld_device"));
+                LDValue[] events = getEventsFromLastRequest(mockEventsServer, 1);
+                LDValue identifyEvent = events[0];
+                assertFalse(identifyEvent.get("context").toString().contains("ld_application"));
+                assertFalse(identifyEvent.get("context").toString().contains("ld_device"));
             }
         }
     }
@@ -345,7 +335,6 @@ public class LDClientEventTest {
 
     private void assertFeatureEvent(LDValue event, LDContext context) {
         assertEquals("feature", event.get("kind").stringValue());
-        assertContextKeys(event, context);
     }
 
     private void assertCustomEvent(LDValue event, LDContext context, String eventKey) {


### PR DESCRIPTION
**Related issues**

236700

**Describe the solution you've provided**

Eliminated recording of evaluation GET command which was leading to race condition in unit tests.
