### PR TITLE
feat: polling data source now supports one shot configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 #        java_version: ['11', '17']
         android_api_level: ['25']
         java_version: ['17']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       # This enables hardware acceleration on large linux runners

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ComponentsImpl.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ComponentsImpl.java
@@ -269,11 +269,11 @@ abstract class ComponentsImpl {
             long elapsedSinceUpdate = System.currentTimeMillis() - lastUpdated;
             long initialDelayMillis = Math.max(pollInterval - elapsedSinceUpdate, 0);
 
-            int maxNumPolls = -1; // negative for unlimited number of polls
+            long maxNumPolls = Long.MAX_VALUE; // effectively unlimited number of polls
             if (oneShot) {
                 if (initialDelayMillis > 0) {
                     clientContext.getBaseLogger().info("One shot polling attempt will be blocked by rate limiting.");
-                    maxNumPolls = 0; // one shot was blocked by rate limiting logic
+                    maxNumPolls = 0; // one shot was blocked by rate limiting logic, so never poll
                 } else {
                     maxNumPolls = 1; // one shot was not blocked by rate limiting logic
                 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ComponentsImpl.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/ComponentsImpl.java
@@ -264,16 +264,27 @@ abstract class ComponentsImpl {
             }
 
             // To avoid unnecessarily frequent polling requests due to process or application lifecycle, we have added
-            // this initial delay logic. Calculate how much time has passed since the last update, if that is less than
-            // the polling interval, delay by the difference, otherwise 0 delay.
+            // this rate limiting logic. Calculate how much time has passed since the last update, if that is less than
+            // the polling interval, delay to when the next poll would have occurred, otherwise 0 delay.
             long elapsedSinceUpdate = System.currentTimeMillis() - lastUpdated;
             long initialDelayMillis = Math.max(pollInterval - elapsedSinceUpdate, 0);
+
+            int maxNumPolls = -1; // negative for unlimited number of polls
+            if (oneShot) {
+                if (initialDelayMillis > 0) {
+                    clientContext.getBaseLogger().info("One shot polling attempt will be blocked by rate limiting.");
+                    maxNumPolls = 0; // one shot was blocked by rate limiting logic
+                } else {
+                    maxNumPolls = 1; // one shot was not blocked by rate limiting logic
+                }
+            }
 
             return new PollingDataSource(
                     clientContextImpl.getEvaluationContext(),
                     clientContextImpl.getDataSourceUpdateSink(),
                     initialDelayMillis,
                     pollInterval,
+                    maxNumPolls,
                     clientContextImpl.getFetcher(),
                     clientContextImpl.getPlatformState(),
                     clientContextImpl.getTaskExecutor(),

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
@@ -17,11 +17,16 @@ import java.util.concurrent.Future;
  */
 public interface LDClientInterface extends Closeable {
     /**
-     * Checks whether the client is ready to return feature flag values. This is true if either
-     * the client has successfully connected to LaunchDarkly and received feature flags, or the
-     * client has been put into offline mode (in which case it will return only default flag values).
+     * Returns true if the client has successfully connected to LaunchDarkly and received feature flags after
+     * {@link LDClient#init(Application, LDConfig, LDContext, int)} was called.  Also returns true if the SDK is
+     * set to offline mode.
      *
-     * @return true if the client is initialized or offline
+     * Otherwise this returns false until the client is able to retrieve latest feature flag data from
+     * LaunchDarkly services. This includes not connecting to LaunchDarkly within the start wait time provided to
+     * {@link LDClient#init(Application, LDConfig, LDContext, int)} even if the SDK has cached feature flags.
+     *
+     * @return true if the client is able to retrieve flag data from LaunchDarkly or offline, false if the client has been
+     * unable to up to this point.
      */
     boolean isInitialized();
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
@@ -18,8 +18,10 @@ import java.util.concurrent.Future;
 public interface LDClientInterface extends Closeable {
     /**
      * Returns true if the client has successfully connected to LaunchDarkly and received feature flags after
-     * {@link LDClient#init(Application, LDConfig, LDContext, int)} was called.  Also returns true if the SDK is
-     * set to offline mode.
+     * {@link LDClient#init(Application, LDConfig, LDContext, int)} was called.
+     *
+     * Also returns true if the SDK knows it will never be able to fetch flag data (such as when the client is set
+     * to offline mode or if in one shot configuration, the one shot fails).
      *
      * Otherwise this returns false until the client is able to retrieve latest feature flag data from
      * LaunchDarkly services. This includes not connecting to LaunchDarkly within the start wait time provided to

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/PollingDataSource.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/PollingDataSource.java
@@ -22,8 +22,7 @@ final class PollingDataSource implements DataSource {
     private final DataSourceUpdateSink dataSourceUpdateSink;
     final long initialDelayMillis; // visible for testing
     final long pollIntervalMillis; // visible for testing
-    private final int maxNumberOfPolls;
-    int numberOfPollsRemaining; // visible for testing
+    long numberOfPollsRemaining; // visible for testing
     private final FeatureFetcher fetcher;
     private final PlatformState platformState;
     private final TaskExecutor taskExecutor;
@@ -37,7 +36,7 @@ final class PollingDataSource implements DataSource {
      *                             source will report success immediately as it is now running even if data has not been
      *                             fetched.
      * @param pollIntervalMillis   interval in millis between each polling request
-     * @param maxNumberOfPolls     the maximum number of polling attempts, unlimited if negative is provided
+     * @param maxNumberOfPolls     the maximum number of polling attempts, use Long.MAX for effectively unlimited.
      * @param fetcher              that will be used for each fetch
      * @param platformState        used for making decisions based on platform state
      * @param taskExecutor         that will be used to schedule the polling tasks
@@ -48,7 +47,7 @@ final class PollingDataSource implements DataSource {
             DataSourceUpdateSink dataSourceUpdateSink,
             long initialDelayMillis,
             long pollIntervalMillis,
-            int maxNumberOfPolls,
+            long maxNumberOfPolls,
             FeatureFetcher fetcher,
             PlatformState platformState,
             TaskExecutor taskExecutor,
@@ -58,7 +57,6 @@ final class PollingDataSource implements DataSource {
         this.dataSourceUpdateSink = dataSourceUpdateSink;
         this.initialDelayMillis = initialDelayMillis;
         this.pollIntervalMillis = pollIntervalMillis;
-        this.maxNumberOfPolls = maxNumberOfPolls;
         this.numberOfPollsRemaining = maxNumberOfPolls;
         this.fetcher = fetcher;
         this.platformState = platformState;
@@ -68,7 +66,7 @@ final class PollingDataSource implements DataSource {
 
     @Override
     public void start(final Callback<Boolean> resultCallback) {
-        if (maxNumberOfPolls == 0) {
+        if (numberOfPollsRemaining <= 0) {
             // If there are no polls to be made, we will immediately report the successful start of the data source.  This
             // may seem strange, but one can think of this data source as behaving like a no-op in this configuration.
             resultCallback.onSuccess(true);
@@ -76,8 +74,8 @@ final class PollingDataSource implements DataSource {
         }
 
         Runnable pollRunnable = () -> poll(resultCallback);
-        logger.debug("Scheduling polling task with interval of {}ms, starting after {}ms, with max number of polls of {}",
-                pollIntervalMillis, initialDelayMillis, maxNumberOfPolls);
+        logger.debug("Scheduling polling task with interval of {}ms, starting after {}ms, with number of polls {}",
+                pollIntervalMillis, initialDelayMillis, numberOfPollsRemaining);
         ScheduledFuture<?> task = taskExecutor.startRepeatingTask(pollRunnable,
                 initialDelayMillis, pollIntervalMillis);
         currentPollTask.set(task);
@@ -93,15 +91,13 @@ final class PollingDataSource implements DataSource {
     }
 
     private void poll(Callback<Boolean> resultCallback) {
-        // poll if there is no max (negative number) or there are polls remaining
-        if (maxNumberOfPolls < 0 || numberOfPollsRemaining > 0) {
+        // poll if there are polls remaining
+        if (numberOfPollsRemaining > 0) {
+            numberOfPollsRemaining--;
             ConnectivityManager.fetchAndSetData(fetcher, context, dataSourceUpdateSink,
                     resultCallback, logger);
-            numberOfPollsRemaining--; // decrementing even when we have unlimited polls has no consequence
-        }
-
-        // terminate if we have a max number of polls and no polls remaining
-        if (maxNumberOfPolls >= 0 && numberOfPollsRemaining <= 0) {
+        } else {
+            // terminate if we have no polls remaining
             ScheduledFuture<?> task = currentPollTask.getAndSet(null);
             if (task != null) {
                 task.cancel(true);

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/PollingDataSource.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/PollingDataSource.java
@@ -28,8 +28,7 @@ final class PollingDataSource implements DataSource {
     private final PlatformState platformState;
     private final TaskExecutor taskExecutor;
     private final LDLogger logger;
-    private final AtomicReference<ScheduledFuture<?>> currentPollTask =
-            new AtomicReference<>();
+    final AtomicReference<ScheduledFuture<?>> currentPollTask = new AtomicReference<>(); // visible for testing
 
     /**
      * @param context              that this data source will fetch data for

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/integrations/PollingDataSourceBuilder.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/integrations/PollingDataSourceBuilder.java
@@ -47,6 +47,13 @@ public abstract class PollingDataSourceBuilder implements ComponentConfigurer<Da
     protected int pollIntervalMillis = DEFAULT_POLL_INTERVAL_MILLIS;
 
     /**
+     * If true, the polling data source will make at most one poll attempt to get
+     * feature flag updates. The one shot poll may be blocked by rate limiting logic
+     * and will not be retried if that occurs.
+     */
+    protected boolean oneShot = false;
+
+    /**
      * Sets the interval between feature flag updates when the application is running in the background.
      * <p>
      * This is normally a longer interval than the foreground polling interval ({@link #pollIntervalMillis(int)}).
@@ -78,6 +85,17 @@ public abstract class PollingDataSourceBuilder implements ComponentConfigurer<Da
     public PollingDataSourceBuilder pollIntervalMillis(int pollIntervalMillis) {
         this.pollIntervalMillis = pollIntervalMillis <= DEFAULT_POLL_INTERVAL_MILLIS ?
                 DEFAULT_POLL_INTERVAL_MILLIS : pollIntervalMillis;
+        return this;
+    }
+
+    /**
+     * Sets the data source to make one and only one attempt to get feature flag updates.  The one shot
+     * poll may be blocked by rate limiting logic and will not be retried if that occurs.
+     *
+     * @return the builder
+     */
+    public PollingDataSourceBuilder oneShot() {
+        this.oneShot = true;
         return this;
     }
 }


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: polling data source now supports one shot configuration
fix: polling data source no longer reports initialized=true incorrectly when rate limiting delays first poll
END_COMMIT_OVERRIDE

**Requirements**

- [x] I have added test coverage for new or changed functionality

- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)

- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

Adds polling data source one shot mode.  Updated data source to support providing the max number of polls to make. 
 Updated builder to calculate number of polls to make based on one shot configuration.

