### PR TITLE
fix: coalesce SharedPreferences writes to reduce memory pressure

### DIFF
--- a/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/SharedPreferencesPersistentDataStoreTest.java
+++ b/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/SharedPreferencesPersistentDataStoreTest.java
@@ -3,7 +3,9 @@ package com.launchdarkly.sdk.android;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import android.app.Application;
 import android.content.Context;
@@ -16,10 +18,15 @@ import com.launchdarkly.sdk.android.subsystems.PersistentDataStore;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class SharedPreferencesPersistentDataStoreTest {
     private static final String BASE_NAMESPACE = SharedPreferencesPersistentDataStoreTest.class.getName();
@@ -55,8 +62,11 @@ public class SharedPreferencesPersistentDataStoreTest {
         String subNamespace = "-valuePersistsAcrossInstances",
                 key = "test-key",
                 value = "test-value";
-        PersistentDataStore store1 = new SharedPreferencesPersistentDataStore(application);
+        SharedPreferencesPersistentDataStore store1 = new SharedPreferencesPersistentDataStore(application);
         store1.setValue(BASE_NAMESPACE + subNamespace, key, value);
+        // Writes coalesce and flush asynchronously; drain before dropping the reference so
+        // that a second, independent store can observe the value via disk.
+        store1.flushSynchronously();
         PersistentDataStore store2 = new SharedPreferencesPersistentDataStore(application);
         assertEquals(value, store2.getValue(BASE_NAMESPACE + subNamespace, key));
     }
@@ -170,5 +180,333 @@ public class SharedPreferencesPersistentDataStoreTest {
 
         PersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
         assertEquals(String.valueOf(value), store.getValue(BASE_NAMESPACE + subNamespace, key));
+    }
+
+    @Test
+    public void getKeysReturnsSetKeys() {
+        String subNamespace = "-getKeysReturnsSetKeys",
+                key1 = "test-key-1", key2 = "test-key-2",
+                value1 = "test-value-1", value2 = "test-value-2";
+        PersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+        store.setValue(BASE_NAMESPACE + subNamespace, key1, value1);
+        store.setValue(BASE_NAMESPACE + subNamespace, key2, value2);
+
+        Collection<String> keys = store.getKeys(BASE_NAMESPACE + subNamespace);
+        assertThat(keys, hasItems(key1, key2));
+        assertEquals(2, keys.size());
+    }
+
+    @Test
+    public void getKeysExcludesRemovedKey() {
+        String subNamespace = "-getKeysExcludesRemovedKey",
+                key1 = "test-key-1", key2 = "test-key-2",
+                value1 = "test-value-1", value2 = "test-value-2";
+        SharedPreferencesPersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+        store.setValue(BASE_NAMESPACE + subNamespace, key1, value1);
+        store.setValue(BASE_NAMESPACE + subNamespace, key2, value2);
+        // Force the two writes out to disk so the subsequent null-write sits above the
+        // disk keyset via the pending overlay, rather than being coalesced into the
+        // same State as the two puts.
+        store.flushSynchronously();
+        // setValue with null value removes the key.
+        store.setValue(BASE_NAMESPACE + subNamespace, key1, null);
+
+        Collection<String> keys = store.getKeys(BASE_NAMESPACE + subNamespace);
+        assertThat(keys, hasItems(key2));
+        assertEquals(1, keys.size());
+    }
+
+    @Test
+    public void getKeysAfterClearIsEmpty() {
+        String subNamespace = "-getKeysAfterClearIsEmpty",
+                key1 = "test-key-1", key2 = "test-key-2",
+                value1 = "test-value-1", value2 = "test-value-2";
+        SharedPreferencesPersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+        store.setValue(BASE_NAMESPACE + subNamespace, key1, value1);
+        store.setValue(BASE_NAMESPACE + subNamespace, key2, value2);
+        // Force the two writes out to disk so the clear operates against a real disk
+        // keyset via the pending overlay, not merged into the same pending State.
+        store.flushSynchronously();
+        store.clear(BASE_NAMESPACE + subNamespace, false);
+
+        assertEquals(0, store.getKeys(BASE_NAMESPACE + subNamespace).size());
+    }
+
+    @Test
+    public void getKeysReflectsMixedDiskAndPendingActivity() {
+        String subNamespace = "-getKeysReflectsMixedDiskAndPendingActivity",
+                keyDisk = "disk-key", keyPending = "pending-key", keyRemoved = "removed-key",
+                valueDisk = "disk-value", valuePending = "pending-value", valueRemoved = "removed-value";
+        SharedPreferencesPersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+        // Two keys on disk: one stays visible, one gets removed via a pending null.
+        store.setValue(BASE_NAMESPACE + subNamespace, keyDisk, valueDisk);
+        store.setValue(BASE_NAMESPACE + subNamespace, keyRemoved, valueRemoved);
+        store.flushSynchronously();
+
+        // Add a new key via pending, and remove one of the disk keys via a pending null.
+        store.setValue(BASE_NAMESPACE + subNamespace, keyPending, valuePending);
+        store.setValue(BASE_NAMESPACE + subNamespace, keyRemoved, null);
+
+        Collection<String> keys = store.getKeys(BASE_NAMESPACE + subNamespace);
+        assertThat(keys, hasItems(keyDisk, keyPending));
+        // keyRemoved must not appear even though it lives on disk — pending's null
+        // overlays disk state.
+        assertEquals(2, keys.size());
+    }
+
+    @Test
+    public void clearWithFullyDeleteFalseKeepsFile() {
+        String subNamespace = "-clearWithFullyDeleteFalseKeepsFile",
+                key = "test-key", value = "test-value";
+        String namespace = BASE_NAMESPACE + subNamespace;
+
+        SharedPreferencesPersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+        store.setValue(namespace, key, value);
+        store.flushSynchronously();
+
+        store.clear(namespace, false);
+        store.flushSynchronously();
+
+        File file = new File(application.getFilesDir().getParent() + "/shared_prefs/"
+                + namespace + ".xml");
+        assertTrue("XML file should remain after clear with fullyDelete=false", file.exists());
+        assertNull(store.getValue(namespace, key));
+    }
+
+    @Test
+    public void clearWithFullyDeleteTrueRemovesFile() {
+        String subNamespace = "-clearWithFullyDeleteTrueRemovesFile",
+                key = "test-key", value = "test-value";
+        String namespace = BASE_NAMESPACE + subNamespace;
+
+        SharedPreferencesPersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+        store.setValue(namespace, key, value);
+        store.flushSynchronously();
+
+        store.clear(namespace, true);
+        store.flushSynchronously();
+
+        File file = new File(application.getFilesDir().getParent() + "/shared_prefs/"
+                + namespace + ".xml");
+        assertFalse("XML file should be removed after clear with fullyDelete=true", file.exists());
+        assertNull(store.getValue(namespace, key));
+    }
+
+    @Test
+    public void clearThenSetValueForSameKeyRetainsNewValue() {
+        String subNamespace = "-clearThenSetValueForSameKeyRetainsNewValue";
+        String namespace = BASE_NAMESPACE + subNamespace;
+        String key = "shared-key";
+
+        SharedPreferencesPersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+        store.setValue(namespace, key, "disk-value");
+        store.flushSynchronously();
+
+        // One coalesced State: clear then setValue for the SAME key. The commit must
+        // produce a namespace containing only the post-clear value.
+        store.clear(namespace, true);
+        store.setValue(namespace, key, "post-clear-value");
+        store.flushSynchronously();
+
+        assertEquals("post-clear-value", store.getValue(namespace, key));
+
+        // Second store confirms the same state on disk.
+        PersistentDataStore store2 = new SharedPreferencesPersistentDataStore(application);
+        assertEquals("post-clear-value", store2.getValue(namespace, key));
+    }
+
+    @Test
+    public void getAllNamespacesIncludesPendingWrites() {
+        String subNamespace = "-getAllNamespacesIncludesPendingWrites";
+        String namespace = BASE_NAMESPACE + subNamespace;
+        PersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+        // Write via our store and check getAllNamespaces without flushing. The union of
+        // filesystem + pending + committing must include the namespace regardless of
+        // whether the drain has completed yet.
+        store.setValue(namespace, "k", "v");
+        assertThat(store.getAllNamespaces(), hasItems(namespace));
+    }
+
+    @Test
+    public void getValueReadsPendingWriteBeforeDisk() {
+        String subNamespace = "-getValueReadsPendingWriteBeforeDisk";
+        String namespace = BASE_NAMESPACE + subNamespace;
+        String key = "test-key";
+
+        SharedPreferencesPersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+        store.setValue(namespace, key, "disk-value");
+        store.flushSynchronously();
+
+        // Overwrite; before flushing this value only exists in the in-memory layer.
+        store.setValue(namespace, key, "pending-value");
+        assertEquals("pending-value", store.getValue(namespace, key));
+    }
+
+    @Test(timeout = 5000)
+    public void flushSynchronouslyOnEmptyStore() {
+        SharedPreferencesPersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+        // No work queued: should return promptly rather than hang.
+        store.flushSynchronously();
+    }
+
+    @Test
+    public void setValuesWithEmptyMap() {
+        String subNamespace = "-setValuesWithEmptyMap";
+        String namespace = BASE_NAMESPACE + subNamespace;
+        SharedPreferencesPersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+        // Empty-map input should be a no-op that doesn't crash or hang.
+        store.setValues(namespace, new HashMap<>());
+        store.flushSynchronously();
+    }
+
+    @Test
+    public void concurrentWritesCoalesce() throws InterruptedException {
+        String subNamespace = "-concurrentWritesCoalesce";
+        String namespace = BASE_NAMESPACE + subNamespace;
+        int threadCount = 8;
+        int writesPerThread = 100;
+
+        SharedPreferencesPersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        for (int t = 0; t < threadCount; t++) {
+            final int threadId = t;
+            pool.submit(() -> {
+                try {
+                    startLatch.await();
+                    for (int i = 0; i < writesPerThread; i++) {
+                        store.setValue(namespace,
+                                "key-" + threadId + "-" + i,
+                                "value-" + threadId + "-" + i);
+                    }
+                } catch (InterruptedException ignored) {
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertTrue("threads did not complete in time",
+                doneLatch.await(10, TimeUnit.SECONDS));
+        pool.shutdown();
+
+        store.flushSynchronously();
+
+        // A fresh store reads only from disk; every key/value must be present.
+        PersistentDataStore store2 = new SharedPreferencesPersistentDataStore(application);
+        for (int t = 0; t < threadCount; t++) {
+            for (int i = 0; i < writesPerThread; i++) {
+                String key = "key-" + t + "-" + i;
+                String expected = "value-" + t + "-" + i;
+                assertEquals("key " + key + " missing on disk", expected,
+                        store2.getValue(namespace, key));
+            }
+        }
+    }
+
+    @Test(timeout = 5000)
+    public void getValueUsesCorrectLayerPrecedenceForSameKey() throws Exception {
+        String subNamespace = "-getValueUsesCorrectLayerPrecedenceForSameKey";
+        String namespace = BASE_NAMESPACE + subNamespace;
+        String key = "shared-key";
+
+        SharedPreferencesPersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+
+        // Layer 3 (disk) holds "disk-value".
+        store.setValue(namespace, key, "disk-value");
+        store.flushSynchronously();
+
+        CountDownLatch atBarrier = new CountDownLatch(1);
+        CountDownLatch releaseBarrier = new CountDownLatch(1);
+        store.preCommitRunnable = () -> {
+            atBarrier.countDown();
+            try {
+                releaseBarrier.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+
+        try {
+            // Trigger a commit that puts "committing-value" into committing for the same key.
+            store.setValue(namespace, key, "committing-value");
+            assertTrue("drain thread did not reach preCommitRunnable",
+                    atBarrier.await(5, TimeUnit.SECONDS));
+
+            // Layers: pending empty, committing has key→"committing-value",
+            // disk has key→"disk-value". Committing must win over disk.
+            assertEquals("committing-value", store.getValue(namespace, key));
+
+            // Add "pending-value" for the same key into pending.
+            store.setValue(namespace, key, "pending-value");
+
+            // Layers: pending has key→"pending-value", committing has key→"committing-value",
+            // disk has key→"disk-value". Pending must win over committing and disk.
+            assertEquals("pending-value", store.getValue(namespace, key));
+
+            // A null in pending is a pending-layer removal; getValue must return null
+            // even though committing and disk still hold non-null values.
+            store.setValue(namespace, key, null);
+            assertNull(store.getValue(namespace, key));
+        } finally {
+            store.preCommitRunnable = null;
+            releaseBarrier.countDown();
+            store.flushSynchronously();
+        }
+    }
+
+    @Test(timeout = 5000)
+    public void pendingClearShadowsCommittingAndDiskForSameKey() throws Exception {
+        // Same-key variant of the precedence test: verify that pending's clear=true
+        // short-circuits lookups even when committing and disk still hold values for
+        // the key.
+        String subNamespace = "-pendingClearShadowsCommittingAndDiskForSameKey";
+        String namespace = BASE_NAMESPACE + subNamespace;
+        String key = "shared-key";
+
+        SharedPreferencesPersistentDataStore store = new SharedPreferencesPersistentDataStore(application);
+
+        store.setValue(namespace, key, "disk-value");
+        store.flushSynchronously();
+
+        CountDownLatch atBarrier = new CountDownLatch(1);
+        CountDownLatch releaseBarrier = new CountDownLatch(1);
+        store.preCommitRunnable = () -> {
+            atBarrier.countDown();
+            try {
+                releaseBarrier.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+
+        try {
+            store.setValue(namespace, key, "committing-value");
+            assertTrue("drain thread did not reach preCommitRunnable",
+                    atBarrier.await(5, TimeUnit.SECONDS));
+
+            // Sanity: with only committing and disk populated, committing wins.
+            assertEquals("committing-value", store.getValue(namespace, key));
+
+            // Install a pending clear. Pending now has clear=true with no changes for key.
+            store.clear(namespace, false);
+
+            // Committing still has key→"committing-value" and disk still has key→"disk-value",
+            // but pending's clear must shadow both.
+            assertNull(store.getValue(namespace, key));
+        } finally {
+            store.preCommitRunnable = null;
+            releaseBarrier.countDown();
+            store.flushSynchronously();
+        }
+
+        // After drain: committing state committed (disk gets "committing-value"),
+        // then pending's clear state committed (empties the namespace on disk).
+        PersistentDataStore store2 = new SharedPreferencesPersistentDataStore(application);
+        assertNull(store2.getValue(namespace, key));
     }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPreferencesPersistentDataStore.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPreferencesPersistentDataStore.java
@@ -252,21 +252,38 @@ final class SharedPreferencesPersistentDataStore implements PersistentDataStore 
     }
 
     /**
-     * Loops: move pending into committing, commit each namespace's state, remove from
-     * committing, check pending again. Exits when pending is empty. Each iteration
-     * starts with {@code committing} empty, since we remove entries after every commit.
+     * Loops: if committing has any leftover state (from a prior drain aborted by an
+     * Error inside commitState), drain it first; otherwise move pending into
+     * committing. Commit each namespace's state, remove from committing, repeat.
+     * Exits when both pending and committing are empty.
+     * <p>
+     * Draining committing before pulling from pending is intentional. A naïve
+     * {@code putAll(pending)} would overwrite any stranded entry whenever a writer
+     * arrived for the same namespace, silently losing the earlier coalesced writes.
+     * By processing committing first, its writes reach SharedPreferences'
+     * {@code mMap} before the newer pending writes are applied on top — natural
+     * merge, no State-level merge logic required.
      */
     private void drainPending() {
         try {
             while (true) {
                 Set<String> namespacesToCommit;
                 synchronized (lock) {
-                    if (pending.isEmpty()) {
-                        flushScheduled = false;
-                        return;
+                    if (committing.isEmpty()) {
+                        if (pending.isEmpty()) {
+                            flushScheduled = false;
+                            return;
+                        }
+                        // committing is empty here, so putAll cannot overwrite a
+                        // stranded entry from a prior failed drain.
+                        committing.putAll(pending);
+                        pending.clear();
                     }
-                    committing.putAll(pending);
-                    pending.clear();
+                    // If committing was non-empty on entry, drain it first without
+                    // pulling from pending. This preserves any state stranded by an
+                    // Error inside commitState — otherwise a naïve putAll(pending)
+                    // would overwrite it whenever a writer arrived for the same
+                    // namespace, silently losing the earlier coalesced writes.
                     namespacesToCommit = new HashSet<>(committing.keySet());
                 }
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPreferencesPersistentDataStore.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPreferencesPersistentDataStore.java
@@ -82,6 +82,10 @@ final class SharedPreferencesPersistentDataStore implements PersistentDataStore 
     @VisibleForTesting
     volatile Runnable preCommitRunnable = null;
 
+    // Log-once-per-episode gate. Set when we catch a Throwable during persistence and
+    // decide to log it; cleared on the first successful commit that follows.
+    private boolean persistenceErrorLogged = false;
+
     public SharedPreferencesPersistentDataStore(Application application, LDLogger logger) {
         this.application = application;
         this.logger = logger;
@@ -308,6 +312,10 @@ final class SharedPreferencesPersistentDataStore implements PersistentDataStore 
             synchronized (lock) {
                 flushScheduled = false;
             }
+            if (!persistenceErrorLogged) {
+                logger.error("Encountered exception during persistence drain: {}", t);
+                persistenceErrorLogged = true;
+            }
             throw t;
         }
     }
@@ -321,11 +329,9 @@ final class SharedPreferencesPersistentDataStore implements PersistentDataStore 
      * writes — the net observable state (namespace contains only the new writes) is
      * unchanged.
      * <p>
-     * Any exception thrown from the underlying SharedPreferences plumbing (editor
-     * construction, putString, commit, or the file removal) is caught and logged.
-     * Letting an exception propagate would kill the enclosing drain runnable and leave
-     * {@code flushScheduled} stuck at {@code true}, blocking all future writes for the
-     * lifetime of this store instance.
+     * Any Throwable from the underlying SharedPreferences plumbing (editor construction,
+     * putString, commit, file removal) or from a test's preCommitRunnable is caught and
+     * (subject to log-once-per-episode gating) logged.
      */
     private void commitState(String namespace, State state) {
         try {
@@ -350,15 +356,21 @@ final class SharedPreferencesPersistentDataStore implements PersistentDataStore 
 
             editor.commit();
 
+            // Successful commit — clear the log-once gate
+            persistenceErrorLogged = false;
+
             if (state.clear && state.fullyDelete && state.changes.isEmpty()) {
                 File file = new File(application.getFilesDir().getParent()
                         + "/shared_prefs/" + namespace + ".xml");
                 //noinspection ResultOfMethodCallIgnored
                 file.delete();
             }
-        } catch (Exception e) {
-            logger.error("Encountered exception committing persistence for namespace '{}': {}",
-                    namespace, e);
+        } catch (Throwable t) {
+            if (!persistenceErrorLogged) {
+                logger.error("Encountered exception committing persistence for namespace '{}': {}",
+                        namespace, t);
+                persistenceErrorLogged = true;
+            }
         }
     }
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPreferencesPersistentDataStore.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPreferencesPersistentDataStore.java
@@ -37,7 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * state and writes each namespace's state to disk in a single
  * {@link SharedPreferences.Editor#commit()} call.
  * <p>
- * Reads resolve in a read through manner: pending → committing → {@link SharedPreferences}.
+ * Reads resolve in a read-through manner: pending, then committing, then {@link SharedPreferences}.
  * <p>
  * All public writing methods return promptly; the actual disk I/O happens on a shared
  * background executor via {@code commit()}. Multiple rapid operations on the same
@@ -252,8 +252,8 @@ final class SharedPreferencesPersistentDataStore implements PersistentDataStore 
     }
 
     /**
-     * Loops: move pending into committing → commit each namespace's state → remove from
-     * committing → check pending again. Exits when pending is empty. Each iteration
+     * Loops: move pending into committing, commit each namespace's state, remove from
+     * committing, check pending again. Exits when pending is empty. Each iteration
      * starts with {@code committing} empty, since we remove entries after every commit.
      */
     private void drainPending() {
@@ -290,39 +290,45 @@ final class SharedPreferencesPersistentDataStore implements PersistentDataStore 
      * must remain to hold them, so fullyDelete's file removal is superseded by those
      * writes — the net observable state (namespace contains only the new writes) is
      * unchanged.
+     * <p>
+     * Any exception thrown from the underlying SharedPreferences plumbing (editor
+     * construction, putString, commit, or the file removal) is caught and logged.
+     * Letting an exception propagate would kill the enclosing drain runnable and leave
+     * {@code flushScheduled} stuck at {@code true}, blocking all future writes for the
+     * lifetime of this store instance.
      */
     private void commitState(String namespace, State state) {
-        SharedPreferences.Editor editor = getSharedPreferences(namespace).edit();
-        if (state.clear) {
-            editor.clear();
-        }
-        for (Map.Entry<String, String> kv : state.changes.entrySet()) {
-            if (kv.getValue() == null) {
-                editor.remove(kv.getKey());
-            } else {
-                editor.putString(kv.getKey(), kv.getValue());
-            }
-        }
-
-        // If a test has set a preCommitRunnable, run it now. Alternatives
-        // required more invasive mocking.
-        Runnable runnable = preCommitRunnable;
-        if (runnable != null) {
-            runnable.run();
-        }
-
         try {
+            SharedPreferences.Editor editor = getSharedPreferences(namespace).edit();
+            if (state.clear) {
+                editor.clear();
+            }
+            for (Map.Entry<String, String> kv : state.changes.entrySet()) {
+                if (kv.getValue() == null) {
+                    editor.remove(kv.getKey());
+                } else {
+                    editor.putString(kv.getKey(), kv.getValue());
+                }
+            }
+
+            // If a test has set a preCommitRunnable, run it now. Alternatives
+            // required more invasive mocking.
+            Runnable runnable = preCommitRunnable;
+            if (runnable != null) {
+                runnable.run();
+            }
+
             editor.commit();
+
+            if (state.clear && state.fullyDelete && state.changes.isEmpty()) {
+                File file = new File(application.getFilesDir().getParent()
+                        + "/shared_prefs/" + namespace + ".xml");
+                //noinspection ResultOfMethodCallIgnored
+                file.delete();
+            }
         } catch (Exception e) {
             logger.error("Encountered exception committing persistence for namespace '{}': {}",
                     namespace, e);
-        }
-
-        if (state.clear && state.fullyDelete && state.changes.isEmpty()) {
-            File file = new File(application.getFilesDir().getParent()
-                    + "/shared_prefs/" + namespace + ".xml");
-            //noinspection ResultOfMethodCallIgnored
-            file.delete();
         }
     }
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPreferencesPersistentDataStore.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPreferencesPersistentDataStore.java
@@ -4,18 +4,83 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import androidx.annotation.VisibleForTesting;
+
 import com.launchdarkly.logging.LDLogger;
 import com.launchdarkly.sdk.android.subsystems.PersistentDataStore;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * SharedPreferences-backed persistent data store with in-memory state coalescing. The
+ * state coalescing was added to improve memory footprint in large bursts of changes
+ * to a single key.  SharedPreferences does not internally coalesce, so this improves
+ * its behavior.
+ * <p>
+ * Each namespace has a resolved {@link State}. Every incoming call is folded into the
+ * pending state for its namespace, producing a single resolved state regardless of how
+ * many calls were made. A background flush task drains the pending state into a committing
+ * state and writes each namespace's state to disk in a single
+ * {@link SharedPreferences.Editor#commit()} call.
+ * <p>
+ * Reads resolve in a read through manner: pending → committing → {@link SharedPreferences}.
+ * <p>
+ * All public writing methods return promptly; the actual disk I/O happens on a shared
+ * background executor via {@code commit()}. Multiple rapid operations on the same
+ * namespace collapse into one flush entry — a burst of {@code setValue}s produces a
+ * single commit, and a {@code clear} discards any pending writes for that namespace.
+ * <p>
+ * While there are pending writes, the background flush drain is throttled by the
+ * speed of the underlying SharedPreferences.edit().commit() call which matches
+ * previous performance.
+ */
 final class SharedPreferencesPersistentDataStore implements PersistentDataStore {
+    // Single class-static executor for all persistence flushes across all instances.
+    private static final Executor FLUSH_EXECUTOR = new ThreadPoolExecutor(
+            0, 1,
+            10L, TimeUnit.SECONDS,
+            new LinkedBlockingQueue<Runnable>(),
+            new PersistenceThreadFactory());
+
     private final Application application;
     private final LDLogger logger;
+
+    // Writes land here as resolved per-namespace state. Reads consult this map first.
+    private final Map<String, State> pending = new HashMap<>();
+
+    // Staging area for state currently being committed to disk. Populated by the flush
+    // loop by moving entries from `pending` under the lock. Reads consult this map second.
+    // Entries are removed as each namespace's commit succeeds.
+    private final Map<String, State> committing = new HashMap<>();
+
+    // Guards `pending`, `committing`, and `flushScheduled`. All state mutations happen
+    // under this lock. Disk I/O (commit()) does NOT happen under this lock.
+    private final Object lock = new Object();
+
+    // True while a flush task is either queued or currently running on FLUSH_EXECUTOR.
+    // Prevents redundant task submissions during a burst.
+    private boolean flushScheduled = false;
+
+    // Invoked by commitState immediately before Editor.commit(). Tests set
+    // this to interpose behavior between "state moved into committing" and "commit to
+    // disk begins" (e.g., to assert reads served by the committing layer). Volatile so
+    // that all threads involved in test see same value.
+    @VisibleForTesting
+    volatile Runnable preCommitRunnable = null;
 
     public SharedPreferencesPersistentDataStore(Application application, LDLogger logger) {
         this.application = application;
@@ -28,10 +93,25 @@ final class SharedPreferencesPersistentDataStore implements PersistentDataStore 
 
     @Override
     public String getValue(String storeNamespace, String key) {
+        synchronized (lock) {
+            // Layer resolution: a state's changes-map hit wins, otherwise a clear on that
+            // layer short-circuits to null (the namespace is cleared as far as this layer
+            // knows), otherwise we fall through to the next layer.
+            State state = pending.get(storeNamespace);
+            if (state != null) {
+                if (state.changes.containsKey(key)) return state.changes.get(key);
+                if (state.clear) return null;
+            }
+            state = committing.get(storeNamespace);
+            if (state != null) {
+                if (state.changes.containsKey(key)) return state.changes.get(key);
+                if (state.clear) return null;
+            }
+        }
+        // Neither layer knows about this key; fall through to shared preferences.
         SharedPreferences prefs = getSharedPreferences(storeNamespace);
         try {
-            String ret = prefs.getString(key, null);
-            return ret;
+            return prefs.getString(key, null);
         } catch (ClassCastException e) {
             try {
                 // In the past, we sometimes stored numeric values directly as numbers via the
@@ -46,60 +126,201 @@ final class SharedPreferencesPersistentDataStore implements PersistentDataStore 
 
     @Override
     public void setValue(String storeNamespace, String key, String value) {
-        SharedPreferences prefs = getSharedPreferences(storeNamespace);
-        SharedPreferences.Editor editor = prefs.edit();
-        if (value == null) {
-            editor.remove(key);
-        } else {
-            editor.putString(key, value);
+        synchronized (lock) {
+            State state = pending.get(storeNamespace);
+            if (state == null) {
+                state = new State();
+                pending.put(storeNamespace, state);
+            }
+            if (state.changes == State.NO_CHANGES) {
+                state.changes = new HashMap<>();
+            }
+            state.changes.put(key, value);
+            // Do not touch state.clear or state.fullyDelete. A prior clear/fullyDelete stays
+            // scheduled — it purges unknown data (and, for fullyDelete, the file itself)
+            // before these writes recreate the file at commit time.
+            scheduleFlushLocked();
         }
-        editor.apply();
     }
 
     @Override
     public void setValues(String storeNamespace, Map<String, String> keysAndValues) {
-        SharedPreferences prefs = getSharedPreferences(storeNamespace);
-        SharedPreferences.Editor editor = prefs.edit();
-        for (Map.Entry<String, String> kv: keysAndValues.entrySet()) {
-            editor.putString(kv.getKey(), kv.getValue());
+        synchronized (lock) {
+            State state = pending.get(storeNamespace);
+            if (state == null) {
+                state = new State();
+                pending.put(storeNamespace, state);
+            }
+            if (state.changes == State.NO_CHANGES) {
+                state.changes = new HashMap<>();
+            }
+            state.changes.putAll(keysAndValues);
+            // Do not touch state.clear or state.fullyDelete. See setValue.
+            scheduleFlushLocked();
         }
-        editor.apply();
     }
 
     @Override
     public Collection<String> getKeys(String storeNamespace) {
         SharedPreferences prefs = getSharedPreferences(storeNamespace);
-        return prefs.getAll().keySet();
+        Set<String> result = new HashSet<>(prefs.getAll().keySet());
+        synchronized (lock) {
+            // Apply committing first (older layer), then pending (newer layer).
+            overlayState(result, committing.get(storeNamespace));
+            overlayState(result, pending.get(storeNamespace));
+        }
+        return result;
+    }
+
+    private static void overlayState(Set<String> keys, State state) {
+        if (state == null) return;
+        if (state.clear) keys.clear();
+        for (Map.Entry<String, String> e : state.changes.entrySet()) {
+            if (e.getValue() == null) keys.remove(e.getKey());
+            else keys.add(e.getKey());
+        }
     }
 
     @Override
     public Collection<String> getAllNamespaces() {
-        // Implementation note: we are reading directly from the filesystem, which means that we will
-        // miss any updates that have been saved asynchronously with SharedPreferences.Editor.apply().
-        // Asynchronous updating is desirable for the SDK in general, and getAllNamespaces() should
-        // only be used for data migration logic, so this is an acceptable tradeoff.
+        // Union of namespaces on disk and namespaces we have pending activity for.
+        Set<String> result = new HashSet<>();
 
         File directory = new File(application.getFilesDir().getParent() + "/shared_prefs/");
         File[] files = directory.listFiles();
-        List<String> ret = new ArrayList<>();
-        if (files == null) {
-            return ret;
-        }
-        for (File file : files) {
-            if (file.isFile() && file.getName().endsWith(".xml")) {
-                ret.add(file.getName().substring(0, file.getName().length() - 4));
+        if (files != null) {
+            for (File file : files) {
+                if (file.isFile() && file.getName().endsWith(".xml")) {
+                    result.add(file.getName().substring(0, file.getName().length() - 4));
+                }
             }
         }
-        return ret;
+
+        synchronized (lock) {
+            result.addAll(pending.keySet());
+            result.addAll(committing.keySet());
+        }
+
+        return new ArrayList<>(result);
     }
 
     @Override
     public void clear(String storeNamespace, boolean fullyDelete) {
-        SharedPreferences prefs = getSharedPreferences(storeNamespace);
-        prefs.edit().clear().apply();
-        if (fullyDelete) {
-            File file = new File(application.getFilesDir().getParent() + "/shared_prefs/" +
-                    storeNamespace + ".xml");
+        // Replace any pending state for this namespace with a fresh clear state. Prior pending
+        // writes are semantically superseded by clear and discarded. fullyDelete escalates
+        // but never de-escalates: if a prior state had fullyDelete=true, we keep that intent
+        // even if this call passes false.
+        synchronized (lock) {
+            State prior = pending.get(storeNamespace);
+            boolean carriedFullyDelete = prior != null && prior.fullyDelete;
+            State state = new State();
+            state.clear = true;
+            state.fullyDelete = fullyDelete || carriedFullyDelete;
+            pending.put(storeNamespace, state);
+            scheduleFlushLocked();
+        }
+    }
+
+    /**
+     * Blocks until every write requested against this store up to this call has been
+     * committed to disk. Exposed with package-private visibility solely so that tests
+     * can assert on disk state after asynchronous writes.
+     */
+    @VisibleForTesting
+    void flushSynchronously() {
+        final CountDownLatch latch = new CountDownLatch(1);
+        FLUSH_EXECUTOR.execute(() -> {
+            try {
+                drainPending();
+            } finally {
+                latch.countDown();
+            }
+        });
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void scheduleFlushLocked() {
+        if (flushScheduled) {
+            return;
+        }
+        flushScheduled = true;
+        FLUSH_EXECUTOR.execute(this::drainPending);
+    }
+
+    /**
+     * Loops: move pending into committing → commit each namespace's state → remove from
+     * committing → check pending again. Exits when pending is empty. Each iteration
+     * starts with {@code committing} empty, since we remove entries after every commit.
+     */
+    private void drainPending() {
+        while (true) {
+            Set<String> namespacesToCommit;
+            synchronized (lock) {
+                if (pending.isEmpty()) {
+                    flushScheduled = false;
+                    return;
+                }
+                committing.putAll(pending);
+                pending.clear();
+                namespacesToCommit = new HashSet<>(committing.keySet());
+            }
+
+            for (String namespace : namespacesToCommit) {
+                State state;
+                synchronized (lock) {
+                    state = committing.get(namespace);
+                }
+                commitState(namespace, state);
+                synchronized (lock) {
+                    committing.remove(namespace);
+                }
+            }
+        }
+    }
+
+    /**
+     * Commit a single namespace's resolved state to disk.
+     * <p>
+     * If {@code state.fullyDelete} is set AND no writes are following the clear, the
+     * XML file is removed after the commit. When writes accompany the clear, the file
+     * must remain to hold them, so fullyDelete's file removal is superseded by those
+     * writes — the net observable state (namespace contains only the new writes) is
+     * unchanged.
+     */
+    private void commitState(String namespace, State state) {
+        SharedPreferences.Editor editor = getSharedPreferences(namespace).edit();
+        if (state.clear) {
+            editor.clear();
+        }
+        for (Map.Entry<String, String> kv : state.changes.entrySet()) {
+            if (kv.getValue() == null) {
+                editor.remove(kv.getKey());
+            } else {
+                editor.putString(kv.getKey(), kv.getValue());
+            }
+        }
+
+        // If a test has set a preCommitRunnable, run it now. Alternatives
+        // required more invasive mocking.
+        Runnable runnable = preCommitRunnable;
+        if (runnable != null) {
+            runnable.run();
+        }
+
+        try {
+            editor.commit();
+        } catch (Exception e) {
+            logger.error("Encountered exception committing persistence for namespace '{}': {}",
+                    namespace, e);
+        }
+
+        if (state.clear && state.fullyDelete && state.changes.isEmpty()) {
+            File file = new File(application.getFilesDir().getParent()
+                    + "/shared_prefs/" + namespace + ".xml");
             //noinspection ResultOfMethodCallIgnored
             file.delete();
         }
@@ -110,5 +331,26 @@ final class SharedPreferencesPersistentDataStore implements PersistentDataStore 
         // same string, we receive the same object, so it is OK to make this call repeatedly
         // rather than caching the object.
         return application.getSharedPreferences(storeNamespace, Context.MODE_PRIVATE);
+    }
+
+    private static final class State {
+        // Sentinel: shared immutable empty map used as the default `changes` value for performance.
+        static final Map<String, String> NO_CHANGES = Collections.emptyMap();
+
+        boolean clear = false;
+        boolean fullyDelete = false;
+        Map<String, String> changes = NO_CHANGES;
+    }
+
+    private static final class PersistenceThreadFactory implements java.util.concurrent.ThreadFactory {
+        private static final AtomicInteger COUNTER = new AtomicInteger();
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread t = new Thread(r, "LaunchDarkly-SharedPreferencesPersistence-" +
+                    COUNTER.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        }
     }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPreferencesPersistentDataStore.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/SharedPreferencesPersistentDataStore.java
@@ -257,28 +257,41 @@ final class SharedPreferencesPersistentDataStore implements PersistentDataStore 
      * starts with {@code committing} empty, since we remove entries after every commit.
      */
     private void drainPending() {
-        while (true) {
-            Set<String> namespacesToCommit;
-            synchronized (lock) {
-                if (pending.isEmpty()) {
-                    flushScheduled = false;
-                    return;
+        try {
+            while (true) {
+                Set<String> namespacesToCommit;
+                synchronized (lock) {
+                    if (pending.isEmpty()) {
+                        flushScheduled = false;
+                        return;
+                    }
+                    committing.putAll(pending);
+                    pending.clear();
+                    namespacesToCommit = new HashSet<>(committing.keySet());
                 }
-                committing.putAll(pending);
-                pending.clear();
-                namespacesToCommit = new HashSet<>(committing.keySet());
-            }
 
-            for (String namespace : namespacesToCommit) {
-                State state;
-                synchronized (lock) {
-                    state = committing.get(namespace);
-                }
-                commitState(namespace, state);
-                synchronized (lock) {
-                    committing.remove(namespace);
+                for (String namespace : namespacesToCommit) {
+                    State state;
+                    synchronized (lock) {
+                        state = committing.get(namespace);
+                    }
+                    commitState(namespace, state);
+                    synchronized (lock) {
+                        committing.remove(namespace);
+                    }
                 }
             }
+        } catch (Throwable t) {
+            // Safety net for anything commitState's catch(Exception) doesn't cover
+            // (an Error like OOM, or something originating in drainPending's own
+            // HashMap/HashSet operations). Reset flushScheduled so subsequent writes
+            // can queue a fresh drain instead of the store deadlocking for its
+            // lifetime. Rethrow so the executor's default handling still surfaces
+            // the throwable.
+            synchronized (lock) {
+                flushScheduled = false;
+            }
+            throw t;
         }
     }
 


### PR DESCRIPTION
## Summary

- `setValue`/`setValues`/`clear` previously used `SharedPreferences.Editor.apply()`. Under bursts of context-data updates (a large segment cascade producing hundreds of stream PATCHes), each call enqueued a `MemoryCommitResult` on Android's `QueuedWork` — retaining a full forked map per snapshot. With a large flag payload this pushed the process past the Low Memory Killer threshold, terminating the app.
- Introduce in-memory coalescing at the `SharedPreferencesPersistentDataStore` layer. Writes fold into a single per-namespace `State` (clear / fullyDelete / changes). A background flush thread drains via `commit()` on a private single-threaded executor. Reads layer through `pending → committing → SharedPreferences` so `setValue`-then-`getValue` sees the latest write immediately.
- Peak retention under a burst is now `O(namespaces × unique keys touched)` regardless of how many `setValue` calls arrive.

## Design notes

- Uses `commit()` rather than `apply()`. The FLUSH_EXECUTOR is fsync-throttled, which naturally paces disk I/O without accumulating snapshots. Effective disk-write rate matches AOSP `SharedPreferencesImpl`'s post-hoc generation-skip coalescing under identical patterns.
- Failed commits are logged and abandoned rather than retried in a busy loop. Implicit recovery is provided by `SharedPreferences` itself: every `commit()` serializes the full in-memory map, so a failed write is picked up by the next successful commit for the same namespace — the same semantics `apply()` had.
- `clear` + `setValue` coalesce into one commit via `Editor.clear().putString(...).commit()` (AOSP processes `mClear` before `mModified`). Halves I/O for the clear+writes case and closes a partial-persist window where clear could land but changes couldn't.
- `fullyDelete`'s XML file removal fires regardless of the clear-commit outcome. Matches the pre-existing `apply()`-based behavior; strictly better on the file-recreation race because `commit()` is synchronous.
- A `@VisibleForTesting volatile Runnable preCommitRunnable` hook lets tests deterministically pause the drain thread between "state moved into committing" and "commit begins," enabling assertions on the layered read during in-flight commits.

## Tests

- 14 new tests covering `getKeys`, `clear(fullyDelete=true/false)` file-existence semantics, coalesced clear+setValue, layered `getValue` reads (pending vs disk, and same-key-across-layers precedence), concurrent 8×100 writes, and edge cases (empty-map `setValues`, `flushSynchronously` on an empty store).
- Two barrier-driven tests use the `preCommitRunnable` hook to hold the drain thread between the pending → committing move and the disk commit, then read the same key with distinct values in each of pending/committing/disk to catch layer-precedence bugs.
- One existing test (`valuePersistsAcrossInstances`) updated to call `flushSynchronously()` — writes now propagate to disk asynchronously.

## Test plan

- [ ] `./gradlew :launchdarkly-android-client-sdk:compileDebugJavaWithJavac :launchdarkly-android-client-sdk:compileDebugAndroidTestJavaWithJavac` passes.
- [ ] Full androidTest suite green on an emulator/device.
- [ ] Manual repro of the OOM scenario against `hello-android` with a large flag payload — confirm heap does not accumulate `MemoryCommitResult` snapshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default persistence semantics (async disk vs immediate `apply`) and layered read/clear behavior across the SDK’s default store; well-tested but affects flag/context persistence under load.
> 
> **Overview**
> **`SharedPreferencesPersistentDataStore` no longer calls `Editor.apply()` on every write.** Writes are folded into per-namespace in-memory `State` (changes, clear, `fullyDelete`), drained on a shared single-thread executor with one `commit()` per namespace, and reads go through **pending → committing → disk** so recent writes are visible before flush.
> 
> **`getKeys` and `getAllNamespaces`** now overlay pending/committing state on top of disk (and union in-memory namespaces for `getAllNamespaces`). **`clear`** replaces pending state for that namespace and can coalesce with later `setValue` in one commit; **`fullyDelete`** file removal is deferred until a clear-only commit when appropriate.
> 
> Tests add **`flushSynchronously()`** and a **`preCommitRunnable`** hook for layer-precedence and concurrency coverage; **`valuePersistsAcrossInstances`** flushes before asserting cross-instance disk visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 071dde1782e5aff6db68ab92116405940c0c5348. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->