### PR TITLE
test: declare polling-gzip contract test capability

### DIFF
--- a/contract-tests/src/main/java/com/launchdarkly/sdktest/TestService.java
+++ b/contract-tests/src/main/java/com/launchdarkly/sdktest/TestService.java
@@ -38,6 +38,7 @@ public class TestService extends NanoHTTPD {
             "inline-context-all",
             "anonymous-redaction",
             "client-prereq-events",
+            "polling-gzip",
             "evaluation-hooks",
             "track-hooks",
             "client-per-context-summaries",


### PR DESCRIPTION
## What

Declares the `polling-gzip` contract-test capability for the Android client SDK, so the sdk-test-harness verifies `Accept-Encoding: gzip` on FDv2 polling requests.

Part of epic **SDK-950** (Polling Gzip Support) · ticket **SDK-2719**.

## Why this is capability-only

The Android SDK already requests and decompresses gzip on the FDv2 polling client transparently via OkHttp's `BridgeInterceptor` (the SDK sets no `Accept-Encoding` header and adds no encoding interceptor; the events-only gzip-disable flag does not touch the polling client). No SDK code change is required — only the capability declaration.

The harness's client-side polling suite is ungated, so declaring the capability activates the `Accept-Encoding: gzip` assertion within it.

## Changes

- `contract-tests/src/main/java/com/launchdarkly/sdktest/TestService.java` — add `"polling-gzip"` to `CAPABILITIES`

## Verification

Not runnable locally (Android contract tests require an emulator). Validated by CI. Note the sibling PRs for the Go and Java server SDKs — which use the same OkHttp/transparent-gzip mechanism — pass the harness polling suite locally, including the `polling/requests/method and headers` assertion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single capability string in the contract-test adapter; no production SDK or auth/data-path changes.
> 
> **Overview**
> **Declares `polling-gzip`** in the Android contract-test service’s `CAPABILITIES` list (`TestService.java`), so the sdk-test-harness treats the client as supporting gzip on FDv2 polling and runs the **`Accept-Encoding: gzip`** header checks in the client-side polling suite.
> 
> No Android SDK networking changes in this PR—the OkHttp stack already negotiates gzip transparently; this change only **advertises** that behavior to the harness (SDK-950 / SDK-2719).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f4b3236c886ad87d84918a9479925c583fa3139. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->