### PR TITLE
fix: add defensive cycle guard to prerequisite evaluation

### DIFF
--- a/contract-tests/src/main/java/com/launchdarkly/sdktest/TestService.java
+++ b/contract-tests/src/main/java/com/launchdarkly/sdktest/TestService.java
@@ -38,6 +38,7 @@ public class TestService extends NanoHTTPD {
             "inline-context-all",
             "anonymous-redaction",
             "client-prereq-events",
+            "client-prereq-cycle-detection",
             "polling-gzip",
             "evaluation-hooks",
             "track-hooks",

--- a/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientEventTest.java
+++ b/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientEventTest.java
@@ -239,6 +239,151 @@ public class LDClientEventTest {
         }
     }
 
+    // Cycle-detection tests exercise CSPE 1.2.5, 1.2.5.1, and 1.2.5.2. Prior to the cycle guard,
+    // any of these configurations would cause a StackOverflowError on the first variation() call.
+    // The tests set up a cyclic prerequisite graph via the persistent store, evaluate one flag on
+    // the cycle, and assert (a) the SDK returns the flag's cached value unchanged and (b) summary
+    // counters reflect each cycle-safe descent exactly once.
+
+    @Test
+    public void flagEvaluationWithSelfLoopPrereqReturnsCachedValue() throws IOException, InterruptedException {
+        try (MockWebServer mockEventsServer = new MockWebServer()) {
+            mockEventsServer.start();
+            mockEventsServer.enqueue(new MockResponse());
+
+            // flagA's only prerequisite is itself. The cycle guard must skip the self-prereq.
+            Flag flagA = new FlagBuilder("flagA").prerequisites(new String[]{"flagA"}).version(1)
+                    .variation(1).value(LDValue.of(true)).reason(EvaluationReason.targetMatch()).build();
+            PersistentDataStore store = new InMemoryPersistentDataStore();
+            TestUtil.writeFlagUpdateToStore(store, mobileKey, ldContext, flagA);
+            LDConfig ldConfig = baseConfigBuilder(mockEventsServer)
+                    .persistentDataStore(store).build();
+
+            try (LDClient client = LDClient.init(application, ldConfig, ldContext, 0)) {
+                // Requirement 1.2.5.1: the requested flag's cached value is returned unchanged.
+                assertTrue(client.boolVariation("flagA", false));
+                client.blockingFlush();
+
+                LDValue[] events = getEventsFromLastRequest(mockEventsServer, 2);
+                LDValue summaryEvent = events[1];
+                assertSummaryEvent(summaryEvent);
+                // flagA is counted exactly once (top-level); the cyclic self-prereq does not
+                // recurse and therefore does not increment the counter.
+                assertEquals(LDValue.of(1), summaryEvent.get("features").get("flagA").get("counters").get(0).get("count"));
+            }
+        }
+    }
+
+    @Test
+    public void flagEvaluationWithTwoCyclePrereqReturnsCachedValue() throws IOException, InterruptedException {
+        try (MockWebServer mockEventsServer = new MockWebServer()) {
+            mockEventsServer.start();
+            mockEventsServer.enqueue(new MockResponse());
+
+            // flagA <-> flagB. Evaluating flagA descends into flagB; flagB's prereq flagA is on the
+            // ancestor path so the cycle guard skips it.
+            Flag flagA = new FlagBuilder("flagA").prerequisites(new String[]{"flagB"}).version(1)
+                    .variation(1).value(LDValue.of(true)).reason(EvaluationReason.targetMatch()).build();
+            Flag flagB = new FlagBuilder("flagB").prerequisites(new String[]{"flagA"}).version(1)
+                    .variation(1).value(LDValue.of(true)).reason(EvaluationReason.targetMatch()).build();
+            PersistentDataStore store = new InMemoryPersistentDataStore();
+            TestUtil.writeFlagUpdateToStore(store, mobileKey, ldContext, flagA);
+            TestUtil.writeFlagUpdateToStore(store, mobileKey, ldContext, flagB);
+            LDConfig ldConfig = baseConfigBuilder(mockEventsServer)
+                    .persistentDataStore(store).build();
+
+            try (LDClient client = LDClient.init(application, ldConfig, ldContext, 0)) {
+                assertTrue(client.boolVariation("flagA", false));
+                client.blockingFlush();
+
+                LDValue[] events = getEventsFromLastRequest(mockEventsServer, 2);
+                LDValue summaryEvent = events[1];
+                assertSummaryEvent(summaryEvent);
+                // flagA: top-level (1). flagB: reached as prereq of flagA (1). Cyclic descent into
+                // flagA from flagB is skipped, so flagA is not double-counted.
+                assertEquals(LDValue.of(1), summaryEvent.get("features").get("flagA").get("counters").get(0).get("count"));
+                assertEquals(LDValue.of(1), summaryEvent.get("features").get("flagB").get("counters").get(0).get("count"));
+            }
+        }
+    }
+
+    @Test
+    public void flagEvaluationWithThreeCyclePrereqReturnsCachedValue() throws IOException, InterruptedException {
+        try (MockWebServer mockEventsServer = new MockWebServer()) {
+            mockEventsServer.start();
+            mockEventsServer.enqueue(new MockResponse());
+
+            // A -> B -> C -> A. Deepest cycle-safe descent reaches C; C's prereq A is on the
+            // ancestor path and is skipped.
+            Flag flagA = new FlagBuilder("flagA").prerequisites(new String[]{"flagB"}).version(1)
+                    .variation(1).value(LDValue.of(true)).reason(EvaluationReason.targetMatch()).build();
+            Flag flagB = new FlagBuilder("flagB").prerequisites(new String[]{"flagC"}).version(1)
+                    .variation(1).value(LDValue.of(true)).reason(EvaluationReason.targetMatch()).build();
+            Flag flagC = new FlagBuilder("flagC").prerequisites(new String[]{"flagA"}).version(1)
+                    .variation(1).value(LDValue.of(true)).reason(EvaluationReason.targetMatch()).build();
+            PersistentDataStore store = new InMemoryPersistentDataStore();
+            TestUtil.writeFlagUpdateToStore(store, mobileKey, ldContext, flagA);
+            TestUtil.writeFlagUpdateToStore(store, mobileKey, ldContext, flagB);
+            TestUtil.writeFlagUpdateToStore(store, mobileKey, ldContext, flagC);
+            LDConfig ldConfig = baseConfigBuilder(mockEventsServer)
+                    .persistentDataStore(store).build();
+
+            try (LDClient client = LDClient.init(application, ldConfig, ldContext, 0)) {
+                assertTrue(client.boolVariation("flagA", false));
+                client.blockingFlush();
+
+                LDValue[] events = getEventsFromLastRequest(mockEventsServer, 2);
+                LDValue summaryEvent = events[1];
+                assertSummaryEvent(summaryEvent);
+                assertEquals(LDValue.of(1), summaryEvent.get("features").get("flagA").get("counters").get(0).get("count"));
+                assertEquals(LDValue.of(1), summaryEvent.get("features").get("flagB").get("counters").get(0).get("count"));
+                assertEquals(LDValue.of(1), summaryEvent.get("features").get("flagC").get("counters").get(0).get("count"));
+            }
+        }
+    }
+
+    @Test
+    public void flagEvaluationWithDiamondPrereqCountsSharedDescendantTwice() throws IOException, InterruptedException {
+        try (MockWebServer mockEventsServer = new MockWebServer()) {
+            mockEventsServer.start();
+            mockEventsServer.enqueue(new MockResponse());
+
+            // Diamond: A -> [B, C], B -> [D], C -> [D]. This is NOT a cycle. Per CSPE 1.2.5.2,
+            // ancestor-set (current-path) semantics must let D be reached on each of the two
+            // independent paths — so D's counter must reach 2. A naive "visited across the whole
+            // walk" implementation would incorrectly count D only once; this test guards against
+            // that regression.
+            Flag flagA = new FlagBuilder("flagA").prerequisites(new String[]{"flagB", "flagC"}).version(1)
+                    .variation(1).value(LDValue.of(true)).reason(EvaluationReason.targetMatch()).build();
+            Flag flagB = new FlagBuilder("flagB").prerequisites(new String[]{"flagD"}).version(1)
+                    .variation(1).value(LDValue.of(true)).reason(EvaluationReason.targetMatch()).build();
+            Flag flagC = new FlagBuilder("flagC").prerequisites(new String[]{"flagD"}).version(1)
+                    .variation(1).value(LDValue.of(true)).reason(EvaluationReason.targetMatch()).build();
+            Flag flagD = new FlagBuilder("flagD").version(1)
+                    .variation(1).value(LDValue.of(true)).reason(EvaluationReason.targetMatch()).build();
+            PersistentDataStore store = new InMemoryPersistentDataStore();
+            TestUtil.writeFlagUpdateToStore(store, mobileKey, ldContext, flagA);
+            TestUtil.writeFlagUpdateToStore(store, mobileKey, ldContext, flagB);
+            TestUtil.writeFlagUpdateToStore(store, mobileKey, ldContext, flagC);
+            TestUtil.writeFlagUpdateToStore(store, mobileKey, ldContext, flagD);
+            LDConfig ldConfig = baseConfigBuilder(mockEventsServer)
+                    .persistentDataStore(store).build();
+
+            try (LDClient client = LDClient.init(application, ldConfig, ldContext, 0)) {
+                assertTrue(client.boolVariation("flagA", false));
+                client.blockingFlush();
+
+                LDValue[] events = getEventsFromLastRequest(mockEventsServer, 2);
+                LDValue summaryEvent = events[1];
+                assertSummaryEvent(summaryEvent);
+                assertEquals(LDValue.of(1), summaryEvent.get("features").get("flagA").get("counters").get(0).get("count"));
+                assertEquals(LDValue.of(1), summaryEvent.get("features").get("flagB").get("counters").get(0).get("count"));
+                assertEquals(LDValue.of(1), summaryEvent.get("features").get("flagC").get("counters").get(0).get("count"));
+                assertEquals(LDValue.of(2), summaryEvent.get("features").get("flagD").get("counters").get(0).get("count"));
+            }
+        }
+    }
+
     @Test
     public void additionalHeadersIncludedInEventsRequest() throws IOException, InterruptedException {
         try (MockWebServer mockEventsServer = new MockWebServer()) {

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -677,6 +678,10 @@ public class LDClient implements LDClientInterface, Closeable {
     }
 
     private EvaluationDetail<LDValue> variationDetailInternal(@NonNull String key, @NonNull LDValue defaultValue, boolean checkType, boolean needsReason) {
+        return variationDetailInternal(key, defaultValue, checkType, needsReason, null);
+    }
+
+    private EvaluationDetail<LDValue> variationDetailInternal(@NonNull String key, @NonNull LDValue defaultValue, boolean checkType, boolean needsReason, Set<String> visited) {
         LDContext context = clientContextImpl.getEvaluationContext();
         Flag flag = contextDataManager.getNonDeletedFlag(key); // returns null for nonexistent *or* deleted flag
         EvaluationDetail<LDValue> result;
@@ -689,9 +694,27 @@ public class LDClient implements LDClientInterface, Closeable {
             result = EvaluationDetail.fromValue(defaultValue, EvaluationDetail.NO_VARIATION, EvaluationReason.error(EvaluationReason.ErrorKind.FLAG_NOT_FOUND));
         } else {
             if (flag.getPrerequisites() != null) {
-                // recurse on prerequisites to emulate prereq evaluations occurring with desirable side effects such as events for prereqs
-                for (String prereqKey : flag.getPrerequisites()) {
-                    variationDetailInternal(prereqKey, LDValue.ofNull(), false, false);
+                // Recurse on prerequisites to emulate prereq evaluations occurring with desirable side effects such as events for prereqs.
+                // Cycle detection uses ancestor-set (current-path) semantics: `visited` contains the flag keys on the path
+                // from the top-level evaluation to (but not including) the current flag. Allocate lazily so that variation
+                // calls on prereq-less flags (the common case) do not pay for a HashSet they never use; once created it is
+                // shared for the rest of the walk via add-on-descend / remove-on-ascend, guarded by try/finally so an
+                // exception below cannot leave a stale ancestor entry visible to a sibling branch.
+                if (visited == null) {
+                    visited = new HashSet<>();
+                }
+                visited.add(key);
+                try {
+                    for (String prereqKey : flag.getPrerequisites()) {
+                        if (visited.contains(prereqKey)) {
+                            // Cyclic edge: skip descent and continue with remaining prerequisites. The requested flag's
+                            // value and reason (below) are unchanged.
+                            continue;
+                        }
+                        variationDetailInternal(prereqKey, LDValue.ofNull(), false, false, visited);
+                    }
+                } finally {
+                    visited.remove(key);
                 }
             }
 


### PR DESCRIPTION
## Summary

Adds defensive cycle detection to the recursive prerequisite walk in `LDClient.variationDetailInternal`, bringing the client SDK's behavior into line with the LaunchDarkly server SDK evaluators.

Tracker: [SDK-2706](https://launchdarkly.atlassian.net/browse/SDK-2706). Parent: [SDK-2695](https://launchdarkly.atlassian.net/browse/SDK-2695). Spec change: [sdk-specs#246](https://github.com/launchdarkly/sdk-specs/pull/246) (CSPE 1.2.5, 1.2.5.1, 1.2.5.2). Matching contract-test PR: [sdk-test-harness#384](https://github.com/launchdarkly/sdk-test-harness/pull/384).

## The fix

`variationDetailInternal` now threads a lazily-allocated `HashSet<String>` through the recursion carrying the flag keys on the current evaluation path. Before descending into a prerequisite, the walker checks whether that key is already on the path; if so, it skips that edge and continues with remaining prerequisites at the same level.

- **Lazy allocation**: variation calls on prereq-less flags (the common case) allocate zero collections. The HashSet is created only when the walker descends into a prerequisite for the first time in a call, then reused for the rest of the walk.
- **Mutable add/remove with `try/finally`**: `add(key)` before recursing and `remove(key)` in a `finally`, so the invariant "the set contains exactly the current path" holds even under exceptions.
- **Ancestor-set (current-path) semantics** — this is deliberate. A prerequisite reached via multiple non-cyclic paths (a diamond `A -> [B, C], B -> [D], C -> [D]`) is not a cycle; each path should emit its own prerequisite event. A global visited-set would silently drop the second event; the ancestor-set pattern correctly counts D twice. There is a unit test guarding this.

## Caller-visible behavior on a cycle

The requested flag returns its cached value and reason unchanged. A client-side prerequisite cycle is not surfaced as `MALFORMED_FLAG` and does not fall back to the caller-provided default value. This differs from server-side behavior — the client already holds an authoritative pre-evaluated result from the server; only the ancillary event walk is affected by the cycle.

[SDK-2706]: https://launchdarkly.atlassian.net/browse/SDK-2706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-2695]: https://launchdarkly.atlassian.net/browse/SDK-2695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ