### PR TITLE
fix: publish the hook list safely across threads

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/HookRunner.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/HookRunner.java
@@ -29,11 +29,16 @@ public class HookRunner {
     private static final String UNKNOWN_HOOK_NAME = "unknown hook";
 
     private final LDLogger logger;
-    private final List<Hook> hooks = new ArrayList<>();
+    /**
+     * The hooks to run, which is replaced rather than modified so that a caller of {@link #addHook(Hook)} on one thread
+     * cannot be seen half way by a series running on another. Every method that runs hooks reads this once into a local
+     * and works from that, so the hooks a series ends with are the hooks it began with.
+     */
+    private volatile List<Hook> hooks;
 
     public HookRunner(LDLogger logger, List<Hook> initialHooks) {
         this.logger = logger;
-        this.hooks.addAll(initialHooks);
+        this.hooks = Collections.unmodifiableList(new ArrayList<>(initialHooks));
     }
 
     private String getHookName(Hook hook) {
@@ -46,11 +51,19 @@ public class HookRunner {
         }
     }
 
-    public void addHook(Hook hook) {
-        hooks.add(hook);
+    /**
+     * Adds a hook, which the next series to begin will run. A series already under way runs the hooks it began with.
+     *
+     * @param hook the hook to add
+     */
+    public synchronized void addHook(Hook hook) {
+        List<Hook> updated = new ArrayList<>(hooks);
+        updated.add(hook);
+        hooks = Collections.unmodifiableList(updated);
     }
 
     public EvaluationDetail<LDValue> withEvaluation(String method, String key, LDContext context, LDValue defaultValue, EvaluationMethod evalMethod) {
+        List<Hook> hooks = this.hooks;
         if (hooks.isEmpty()) {
             return evalMethod.evaluate();
         }
@@ -84,6 +97,10 @@ public class HookRunner {
     }
 
     public AfterIdentifyMethod identify(LDContext context, Integer timeout) {
+        // The returned method runs when the identify completes, which is a round trip later, so it closes over these
+        // hooks rather than reading the field again: otherwise a hook added in between would be given an "after" stage
+        // for a series whose "before" stage it was never in.
+        List<Hook> hooks = this.hooks;
         if (hooks.isEmpty()) {
             return (IdentifySeriesResult result) -> {};
         }
@@ -115,6 +132,7 @@ public class HookRunner {
     }
 
     public void afterTrack(String key, LDContext context, LDValue data, Double metricValue) {
+        List<Hook> hooks = this.hooks;
         if (hooks.isEmpty()) {
             return;
         }

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/HookRunnerTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/HookRunnerTest.java
@@ -5,6 +5,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import com.launchdarkly.sdk.EvaluationDetail;
 import com.launchdarkly.sdk.EvaluationReason;
@@ -26,6 +27,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class HookRunnerTest extends EasyMockSupport {
     private HookRunner hookRunner;
@@ -389,6 +393,98 @@ public class HookRunnerTest extends EasyMockSupport {
 
         verifyAll();
         assertSame(evaluationResult, result);
+        logging.assertNothingLogged();
+    }
+
+    @Test
+    public void givesAnEvaluationTheHooksItBeganWith() {
+        List<String> stages = new ArrayList<>();
+        Map<String, Object> seriesData = Collections.unmodifiableMap(Collections.emptyMap());
+
+        Hook addedDuring = mock(Hook.class);
+        expect(addedDuring.beforeEvaluation(anyObject(), anyObject())).andStubAnswer(() -> { stages.add("added:before"); return seriesData; });
+        expect(addedDuring.afterEvaluation(anyObject(), anyObject(), anyObject())).andStubAnswer(() -> { stages.add("added:after"); return seriesData; });
+        expect(testHook.beforeEvaluation(anyObject(), anyObject())).andStubAnswer(() -> {
+            stages.add("first:before");
+            hookRunner.addHook(addedDuring);
+            return seriesData;
+        });
+        expect(testHook.afterEvaluation(anyObject(), anyObject(), anyObject())).andStubAnswer(() -> { stages.add("first:after"); return seriesData; });
+        replayAll();
+
+        EvaluationDetail<LDValue> evaluationResult = EvaluationDetail.fromValue(LDValue.of(true), 1, EvaluationReason.off());
+        HookRunner.EvaluationMethod evaluationMethod = () -> evaluationResult;
+        LDContext context = LDContext.create("user-123");
+        hookRunner.withEvaluation("testMethod", "test-flag", context, LDValue.of(false), evaluationMethod);
+        hookRunner.withEvaluation("testMethod", "test-flag", context, LDValue.of(false), evaluationMethod);
+
+        // A hook registered part way through an evaluation runs from the next one, rather than joining a series whose
+        // earlier stages it was not in.
+        assertEquals(List.of("first:before", "first:after",
+                             "first:before", "added:before", "added:after", "first:after"), stages);
+        logging.assertNothingLogged();
+    }
+
+    @Test
+    public void givesAnIdentifyTheHooksItBeganWith() {
+        LDContext context = LDContext.create("user-123");
+        Integer timeout = 10;
+
+        IdentifySeriesResult identifyResult = new IdentifySeriesResult(IdentifySeriesResult.IdentifySeriesStatus.COMPLETED);
+        IdentifySeriesContext seriesContext = new IdentifySeriesContext(context, timeout);
+        Hook addedDuring = mock(Hook.class);
+
+        expect(testHook.beforeIdentify(seriesContext, Collections.emptyMap())).andReturn(Collections.unmodifiableMap(Collections.emptyMap()));
+        expect(testHook.afterIdentify(seriesContext, Collections.emptyMap(), identifyResult)).andReturn(Collections.unmodifiableMap(Collections.emptyMap()));
+        replayAll();
+
+        // An identify's two stages are separated by a round trip, which is time enough for an application to register a
+        // hook. The new hook is left for the next identify: there is no series data to give it for this one.
+        HookRunner.AfterIdentifyMethod afterIdentifyMethod = hookRunner.identify(context, timeout);
+        hookRunner.addHook(addedDuring);
+        afterIdentifyMethod.invoke(identifyResult);
+
+        verifyAll();
+        logging.assertNothingLogged();
+    }
+
+    @Test
+    public void addsHooksFromSeveralThreadsWithoutLosingAny() throws InterruptedException {
+        int threads = 4;
+        int hooksPerThread = 50;
+        HookRunner runner = new HookRunner(logging.logger, Collections.emptyList());
+        AtomicInteger evaluationsObserved = new AtomicInteger();
+        CountDownLatch startLine = new CountDownLatch(1);
+        CountDownLatch finished = new CountDownLatch(threads);
+
+        for (int i = 0; i < threads; i++) {
+            new Thread(() -> {
+                try {
+                    startLine.await();
+                    for (int j = 0; j < hooksPerThread; j++) {
+                        runner.addHook(new Hook("counting-hook") {
+                            @Override
+                            public Map<String, Object> beforeEvaluation(EvaluationSeriesContext seriesContext, Map<String, Object> seriesData) {
+                                evaluationsObserved.incrementAndGet();
+                                return seriesData;
+                            }
+                        });
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    finished.countDown();
+                }
+            }).start();
+        }
+        startLine.countDown();
+        assertTrue(finished.await(10, TimeUnit.SECONDS));
+
+        EvaluationDetail<LDValue> evaluationResult = EvaluationDetail.fromValue(LDValue.of(true), 1, EvaluationReason.off());
+        runner.withEvaluation("testMethod", "test-flag", LDContext.create("user-123"), LDValue.of(false), () -> evaluationResult);
+
+        // Registrations racing one another are each kept, rather than one thread's copy of the list overwriting another's.
+        assertEquals(threads * hooksPerThread, evaluationsObserved.get());
         logging.assertNothingLogged();
     }
 


### PR DESCRIPTION
**Describe the bug**

`HookRunner` keeps its hooks in a plain `ArrayList` with no synchronization:

```java
private final List<Hook> hooks = new ArrayList<>();

public void addHook(Hook hook) {
    hooks.add(hook);
}
```

`LDClient.addHook` is public API and registering a hook after the client starts is its documented purpose, while `withEvaluation`, `identify` and `afterTrack` all read that list and may all be called from any thread. Four things follow:

- A hook registered on a background thread may never become visible to evaluations on another thread, because nothing establishes a happens-before edge between the `add` and the read.
- It may be seen half written. `ArrayList.add` stores the element and increments `size`, and a reader may observe the new size before the element, so `hooks.get(i)` returns null. The `NullPointerException` is then caught by the stage's own handler and logged as the hook having reported an error, and `getHookName` trips over the same null and logs that it could not read the hook's metadata. Two error lines about a hook that did nothing.
- Two concurrent `addHook` calls can lose one of the hooks or throw from inside `ArrayList` as it grows.
- A hook arriving mid-series unbalances the stages. This one is not about the list being thread-safe: a series read the field once per stage, so a hook appended between the before and after stages left the after loop starting one index beyond what `seriesDataList` reaches, and `seriesDataList.get(i)` threw `IndexOutOfBoundsException`. That call sits inside the try, so it was caught and logged as the new hook failing `afterEvaluation`, a stage it was never in. `identify` holds that window open for a whole round trip, since its after stage runs from the `AfterIdentifyMethod` it returns.

No flag value or event is affected. What it costs is hooks that quietly miss work they should have seen, and error logs blaming hooks for failures that were not theirs.

**Describe the solution you've provided**

The list is replaced rather than modified, and every series reads it once:

```java
private volatile List<Hook> hooks;

public synchronized void addHook(Hook hook) {
    List<Hook> updated = new ArrayList<>(hooks);
    updated.add(hook);
    hooks = Collections.unmodifiableList(updated);
}
```

`withEvaluation`, `identify` and `afterTrack` each take `List<Hook> hooks = this.hooks;` as their first statement and work from that, so a series runs the hooks it began with and its stages stay paired. The method `identify` returns closes over the snapshot rather than the field, which is what keeps a hook registered during the round trip out of the second half of a series it was never in. A hook registered while a series is under way joins the next one.

The volatile read is the only cost on the evaluation path; the copy happens per `addHook`, a handful of times in an application's life.

**One deliberate behavior change**

The before loop re-read `hooks.size()` on every iteration, so a hook registered by an earlier hook's `beforeEvaluation` was picked up by the very series it was registered during. Against a snapshot it joins the next one instead. Nothing documented the old behavior, and it is the same mid-series registration this PR is about: a hook that observes half a series is worse off than one that starts cleanly at the next.

**Describe alternatives you've considered**

- **`CopyOnWriteArrayList`.** One line, and it fixes visibility and concurrent registration, but each `get` consults the current array, so the reads within a single series can still disagree and the unbalanced stages survive. Once the reads are snapshotted the list needs no concurrency of its own.
- **Synchronizing the methods that run hooks.** Serializes evaluations across threads and holds a lock across customer hook code, so a hook that evaluates a flag would deadlock.
- **Making the list final and dropping `addHook`,** which is what the iOS SDK does — its hooks are fixed at initialization and there is no equivalent method, which is why none of this arises there. Not available to us without removing published API.

**Additional context**

Three tests, each of which fails against the current implementation:

- an evaluation runs the hooks it began with, and one registered from inside another hook's before stage runs from the next evaluation;
- a hook registered between an identify's two stages is not given the second of them;
- four threads registering fifty hooks each lose none of them.

Found while working on evaluation exposure deduplication, but independent of it and older than it. Not related to the other Android branch in flight, `andrey/one-flag-read-per-evaluation`; the two touch different files and can land in either order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **`HookRunner`** no longer mutates a shared `ArrayList` for hooks. It keeps a **`volatile` immutable list**, **`addHook`** copies and publishes a new list under **`synchronized`**, and **`withEvaluation`**, **`identify`**, and **`afterTrack`** each read the list once and run a **fixed hook snapshot** for the whole series.
> 
> **Identify**’s returned **`AfterIdentifyMethod`** closes over that snapshot so hooks registered during the round trip do not run **`afterIdentify`** for a series they never entered. Hooks added mid-evaluation (including from another hook’s **`beforeEvaluation`**) take effect on the **next** series, not the current one.
> 
> Three unit tests cover snapshot semantics for evaluation and identify and concurrent **`addHook`** without lost registrations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd34a857b2bd9a1ee9868d630a2039d562e508f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->