### PR TITLE
Do not merge fix: stop the FDv2 synchronizer rotation from spinning (fixes testDebugUnitTest OOM)

### DIFF
--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSource.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/FDv2DataSource.java
@@ -28,6 +28,8 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -53,6 +55,15 @@ final class FDv2DataSource implements DataSource {
     private static final String INITIALIZER_ERROR = "Initializer error: {}";
     private static final String INITIALIZER_CANCELLED = "Initializer cancelled: {}";
     private static final String INITIALIZER_INTERRUPTED = "Initializer interrupted: {}";
+
+    /**
+     * A synchronizer session shorter than this never really connected to anything, so the rotation
+     * to the next synchronizer is paused rather than attempted immediately.
+     */
+    private static final long MIN_SYNCHRONIZER_SESSION_MILLIS = 500;
+
+    /** Upper bound for the growing pause between synchronizer sessions that keep ending at once. */
+    private static final long MAX_ROTATION_PAUSE_MILLIS = 30_000;
 
     private final List<DataSourceFactory<Initializer>> cacheInitializers;
     private final SourceManager sourceManager;
@@ -510,13 +521,36 @@ final class FDv2DataSource implements DataSource {
         logger.info("Synchronizer '{}' reported status: {}.", sourceName, state.name());
     }
 
+    /**
+     * Waits before building the next synchronizer. Waiting on {@link #shutdownCause} rather than
+     * sleeping means a {@link #stop(Callback)} during the pause is acted on right away.
+     *
+     * @return false if the data source shut down while waiting, in which case the caller must stop
+     */
+    private boolean pauseBeforeRotation(long pauseMillis) {
+        logger.debug("Waiting {}ms before trying the next synchronizer.", pauseMillis);
+        try {
+            shutdownCause.get(pauseMillis, TimeUnit.MILLISECONDS);
+            return false;
+        } catch (TimeoutException e) {
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        } catch (ExecutionException e) {
+            return false;
+        }
+    }
+
     private void runSynchronizers(
             @NonNull LDContext context,
             @NonNull DataSourceUpdateSinkV2 sink
     ) {
+        long rotationPauseMillis = 0;
         try {
             Synchronizer synchronizer = sourceManager.getNextAvailableSynchronizerAndSetActive();
             while (synchronizer != null) {
+                long sessionStartNanos = System.nanoTime();
                 String synchronizerName = synchronizer.name();
                 logger.info("Synchronizer '{}' is starting.", synchronizerName);
                 resetSynchronizerStatusDedupe();
@@ -651,6 +685,22 @@ final class FDv2DataSource implements DataSource {
                     Thread.currentThread().interrupt();
                     return;
                 }
+
+                // A source that ends its session at once, such as one reporting SHUTDOWN as soon as
+                // it is built, must not be allowed to drive this rotation at CPU speed. The pause
+                // grows while sessions keep ending immediately and resets once one of them lasts.
+                if (TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - sessionStartNanos)
+                        < MIN_SYNCHRONIZER_SESSION_MILLIS) {
+                    rotationPauseMillis = rotationPauseMillis == 0
+                            ? MIN_SYNCHRONIZER_SESSION_MILLIS
+                            : Math.min(rotationPauseMillis * 2, MAX_ROTATION_PAUSE_MILLIS);
+                    if (!pauseBeforeRotation(rotationPauseMillis)) {
+                        return;
+                    }
+                } else {
+                    rotationPauseMillis = 0;
+                }
+
                 synchronizer = sourceManager.getNextAvailableSynchronizerAndSetActive();
             }
             if (!stopCalled.get()) {

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/FDv2DataSourceTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/FDv2DataSourceTest.java
@@ -517,22 +517,27 @@ public class FDv2DataSourceTest {
 
     @Test
     public void fallbackAndRecoveryTasksWellBehaved() throws Exception {
-        // First sync: changeset then INTERRUPTED; second sync: changeset; recovery brings back first
-        MockQueuedSynchronizer firstSync = new MockQueuedSynchronizer(
-                FDv2SourceResult.changeSet(makeChangeSet(false), false),
-                interrupted());
-        MockQueuedSynchronizer secondSync = new MockQueuedSynchronizer(
-                FDv2SourceResult.changeSet(makeChangeSet(false), false));
-
         AtomicInteger firstCallCount = new AtomicInteger(0);
         AtomicInteger secondCallCount = new AtomicInteger(0);
         MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
 
+        // First sync: changeset then INTERRUPTED; second sync: changeset; recovery brings back first.
+        // Each factory must build a fresh synchronizer, because the data source closes the previous
+        // one when it switches, and a closed synchronizer only ever reports SHUTDOWN.
         FDv2DataSource dataSource = buildDataSource(sink,
                 Collections.emptyList(),
                 Arrays.asList(
-                        () -> { firstCallCount.incrementAndGet(); return firstSync; },
-                        () -> { secondCallCount.incrementAndGet(); return secondSync; }),
+                        () -> {
+                            firstCallCount.incrementAndGet();
+                            return new MockQueuedSynchronizer(
+                                    FDv2SourceResult.changeSet(makeChangeSet(false), false),
+                                    interrupted());
+                        },
+                        () -> {
+                            secondCallCount.incrementAndGet();
+                            return new MockQueuedSynchronizer(
+                                    FDv2SourceResult.changeSet(makeChangeSet(false), false));
+                        }),
                 1, 2);
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -663,17 +668,22 @@ public class FDv2DataSourceTest {
         AtomicInteger firstCallCount = new AtomicInteger(0);
         AtomicInteger secondCallCount = new AtomicInteger(0);
 
-        MockQueuedSynchronizer firstSync = new MockQueuedSynchronizer(
-                FDv2SourceResult.changeSet(makeChangeSet(false), false),
-                interrupted());
-        MockQueuedSynchronizer secondSync = new MockQueuedSynchronizer(
-                FDv2SourceResult.changeSet(makeChangeSet(false), false));
-
+        // Each factory must build a fresh synchronizer, because the data source closes the previous
+        // one when it switches, and a closed synchronizer only ever reports SHUTDOWN.
         FDv2DataSource dataSource = buildDataSource(sink,
                 Collections.emptyList(),
                 Arrays.asList(
-                        () -> { firstCallCount.incrementAndGet(); return firstSync; },
-                        () -> { secondCallCount.incrementAndGet(); return secondSync; }),
+                        () -> {
+                            firstCallCount.incrementAndGet();
+                            return new MockQueuedSynchronizer(
+                                    FDv2SourceResult.changeSet(makeChangeSet(false), false),
+                                    interrupted());
+                        },
+                        () -> {
+                            secondCallCount.incrementAndGet();
+                            return new MockQueuedSynchronizer(
+                                    FDv2SourceResult.changeSet(makeChangeSet(false), false));
+                        }),
                 1, 2);
 
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
@@ -2024,16 +2034,16 @@ public class FDv2DataSourceTest {
     @Test
     public void orchestrationLogging_recovery_logsInfo() throws Exception {
         MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
-        MockQueuedSynchronizer firstSync = new MockQueuedSynchronizer(
-                FDv2SourceResult.changeSet(makeChangeSet(false), false),
-                interrupted());
-        MockQueuedSynchronizer secondSync = new MockQueuedSynchronizer(
-                FDv2SourceResult.changeSet(makeChangeSet(false), false));
+        // Fresh instances per build: the data source closes the previous synchronizer when it
+        // switches, and a closed synchronizer only ever reports SHUTDOWN.
         FDv2DataSource dataSource = buildDataSource(sink,
                 Collections.emptyList(),
                 Arrays.asList(
-                        () -> firstSync,
-                        () -> secondSync),
+                        () -> new MockQueuedSynchronizer(
+                                FDv2SourceResult.changeSet(makeChangeSet(false), false),
+                                interrupted()),
+                        () -> new MockQueuedSynchronizer(
+                                FDv2SourceResult.changeSet(makeChangeSet(false), false))),
                 1, 2);
         AwaitableCallback<Boolean> startCallback = startDataSource(dataSource);
         try {

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/FDv2DataSourceTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/FDv2DataSourceTest.java
@@ -698,6 +698,37 @@ public class FDv2DataSourceTest {
     }
 
     @Test
+    public void synchronizersThatShutDownImmediatelyDoNotSpin() throws Exception {
+        MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
+        AtomicInteger buildCount = new AtomicInteger(0);
+
+        // Every session ends as soon as it starts, so the rotation has nothing to wait on and would
+        // run at CPU speed if it were not rate limited.
+        FDv2DataSource dataSource = buildDataSource(sink,
+                Collections.emptyList(),
+                Arrays.asList(
+                        () -> {
+                            buildCount.incrementAndGet();
+                            return new MockQueuedSynchronizer(
+                                    FDv2SourceResult.status(FDv2SourceResult.Status.shutdown(), false));
+                        },
+                        () -> {
+                            buildCount.incrementAndGet();
+                            return new MockQueuedSynchronizer(
+                                    FDv2SourceResult.status(FDv2SourceResult.Status.shutdown(), false));
+                        }));
+
+        startDataSource(dataSource);
+        Thread.sleep(1500);
+
+        // Pauses of 500ms, 1s, 2s and so on allow only a handful of attempts in this window.
+        int builds = buildCount.get();
+        assertTrue("expected rate limited rotation, but saw " + builds + " synchronizers built",
+                builds <= 6);
+        stopDataSource(dataSource);
+    }
+
+    @Test
     public void fallbackMovesToNextSynchronizer() throws Exception {
         MockComponents.MockDataSourceUpdateSink sink = new MockComponents.MockDataSourceUpdateSink();
         BlockingQueue<Boolean> secondCalledQueue = new LinkedBlockingQueue<>();


### PR DESCRIPTION
## Summary

`FDv2DataSourceTest.recoveryResetsToFirstAvailableSynchronizer` failed CI with `java.lang.OutOfMemoryError`, breaking `testDebugUnitTest` on the 5.14.0 release run. There were two problems: the tests misused the mocks, and the data source turned that misuse into a busy loop instead of a plain failure.

**Tests.** Three recovery tests shared a single `MockQueuedSynchronizer` instance across every call to their synchronizer factory. `FDv2DataSource` closes the previously active synchronizer when it switches sources, so when the recovery condition reset the source index and rebuilt the first synchronizer, the factory handed back an already-closed mock, which reports `SHUTDOWN` from `next()` immediately. Each factory now builds a fresh mock, which is what real synchronizer factories do.

**Data source.** The rotation loop advanced to the next source as soon as a session ended, with no lower bound on how long a session had to last. Two closed mocks therefore rotated as fast as the CPU allowed, writing about three log messages per iteration into the unbounded list in `LogCapture` until the test JVM exhausted its heap. Rotation now pauses when a session ends sooner than it plausibly could have connected, growing the pause up to 30 seconds while sessions keep ending immediately and resetting once a session lasts. The pause waits on `shutdownCause` rather than sleeping, so a `stop()` during it is acted on right away.

The same hazard existed without any mocks: a single configured synchronizer that reports `SHUTDOWN` as soon as it is built would have spun this loop forever in a real app.

## Verification

- New test `synchronizersThatShutDownImmediatelyDoNotSpin` builds two synchronizers that shut down immediately and asserts the rotation stays rate limited. Without the production fix it reports **1,243,438 synchronizers built in 1.5 seconds**; with it, three.
- On unmodified `main` the two recovery tests each ran for the full 10s `awaitApplyCount` timeout, since a closed mock can never deliver the third expected apply, and that 10s of busy-looping is what exhausted the heap under CI's slower conditions. They now finish in ~3.0s, matching the intended 1s fallback plus 2s recovery.
- `:launchdarkly-android-client-sdk:testDebugUnitTest` passes locally: 729 tests, 0 failures. `:launchdarkly-android-client-sdk:lint` is clean.

## Note for reviewers

The inner loop that consumes results from a single synchronizer is still paced entirely by that synchronizer's `next()` future, so a source that resolves `next()` instantly and forever (for example one that reports `INTERRUPTED` with no internal backoff) can still spin. That felt like the source's contract rather than the orchestrator's, so I left it alone; happy to add a bound there too if you'd rather the data source defend against it.

## Test plan

- [ ] CI `build-and-publish` / `testDebugUnitTest` passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **FDv2 synchronizer rotation** no longer advances to the next source the instant a session ends. If a synchronizer session lasts less than **500ms** (e.g. immediate `SHUTDOWN`), `FDv2DataSource` waits before building the next one, with a pause that **doubles** up to **30s** while short sessions keep happening and **resets** once a session runs longer. The wait uses **`shutdownCause`** with a timeout so **`stop()`** can unblock immediately instead of sleeping.
> 
> **Tests** were updated so synchronizer factories return a **new mock** on each build (reusing one instance after `close()` only yields `SHUTDOWN` and triggered the spin). A new test **`synchronizersThatShutDownImmediatelyDoNotSpin`** asserts rotation stays bounded when every synchronizer shuts down on first `next()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69f18b071040fb641a12c83aeac7a906b0a92cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->