### PR TITLE
do not merge ci: stop running the unit test suite twice per build

### DIFF
--- a/launchdarkly-android-client-sdk/build.gradle
+++ b/launchdarkly-android-client-sdk/build.gradle
@@ -52,6 +52,17 @@ android {
     useLibrary("android.test.mock")
 }
 
+androidComponents {
+    // This module has no variant-specific source sets, so the release variant's unit tests compile
+    // and run exactly the same code as the debug variant's. Leaving them enabled makes `check`, and
+    // therefore every CI run, execute the whole suite twice: it doubles the unit test time and
+    // doubles the chance of a run tripping a flaky test. Re-enable if a variant-specific difference
+    // (such as the BuildConfig.DEBUG branch in LDTimberLogging) ever gains unit test coverage.
+    beforeVariants(selector().withBuildType("release")) { variantBuilder ->
+        variantBuilder.enableUnitTest = false
+    }
+}
+
 configurations {
     commonClasses {
         transitive = false


### PR DESCRIPTION
## Context

Follow-up to the investigation of why unit tests seem to fail more often during releases than on PRs. **The short answer is that the unit test setup is identical in both paths** — `ci.yml` (pull requests and pushes) and `publish.yml` (releases) both call `.github/actions/ci` with the same inputs, which runs `./gradlew build jar` followed by `./gradlew test`. There is no release-specific test configuration.

What the failure record actually shows:

| Release publish jobs | Failing test |
| --- | --- |
| 5.12.1 (Jun 2) | `StateDebounceManagerTest > timerResetsOnEachEvent` |
| 5.12.2 (Jun 3) | `StateDebounceManagerTest > callbackNotFiredBeforeDebounceWindow` |
| 5.14.0 (Aug 12) | `FDv2DataSourceTest > recoveryResetsToFirstAvailableSynchronizer` (OOM) |

The first two were wall-clock timing flakes, already made deterministic by #359 and its follow-up; the third is fixed in #384. PR runs hit the same flakes — run 31133027807 failed with the identical FDv2 OOM. Releases are simply where a flake is noticed, because it aborts publishing instead of being quietly re-run.

## The one real defect found

`check` pulls in both `testDebugUnitTest` and `testReleaseUnitTest`, so **every CI run executes all 729 unit tests twice**. This module has no variant-specific source sets, so the second pass compiles and runs identical code. It buys no coverage and costs roughly a minute of CI per run, and more importantly it gives each run two independent chances to trip a flaky test. That asymmetry is visible in the data above: the recent PR failure landed in `testReleaseUnitTest` while the same flake failed the release in `testDebugUnitTest`.

This disables unit tests for the release variant only.

## Verification

- `./gradlew build jar --dry-run` now schedules `:launchdarkly-android-client-sdk:testDebugUnitTest` and no longer `testReleaseUnitTest`; `assembleRelease` and `bundleReleaseAar` are still scheduled.
- `:launchdarkly-android-client-sdk:check` and `:assembleRelease` both pass, and only `testDebugUnitTest` produces results.
- `publishToMavenLocal` still resolves, so the release artifact and its publication are untouched.
- Nothing in the repo (workflows, Makefile, scripts) references `testReleaseUnitTest`.

The comment in `build.gradle` notes the one place where variant behavior actually differs (the `BuildConfig.DEBUG` branch in `LDTimberLogging`, currently untested), so this can be revisited if that ever gains coverage.

## Test plan

- [ ] CI `ci-build` passes with a single unit test pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **CI now runs the Android client SDK unit tests once per build** by turning off unit tests for the **release** build variant in `launchdarkly-android-client-sdk/build.gradle`.
> 
> Gradle’s `check` task previously ran both `testDebugUnitTest` and `testReleaseUnitTest`. This module has no variant-specific sources, so the second pass duplicated the same ~729 tests—adding roughly a minute of CI time and a second independent chance for flaky tests to fail. The change uses `androidComponents.beforeVariants` with `enableUnitTest = false` on the release build type only; debug unit tests remain.
> 
> Release assembly, AAR bundling, and Maven publication are unchanged. A comment documents re-enabling if variant-specific behavior (e.g. `BuildConfig.DEBUG` in `LDTimberLogging`) ever needs release-variant test coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fb2b387c0b450e586c9f8a17a8f61697c8f3b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->