### PR TITLE
test: harden the flakiest unit test and the contract test harness download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ SUPPRESSION_FILE_FDV2=testharness-suppressions-fdv2.txt
 TEST_HARNESS_PARAMS_V2= -status-timeout 60
 TEST_HARNESS_PARAMS_V3= -status-timeout 60
 
+# The downloader script is version-agnostic -- VERSION selects which harness binary it fetches --
+# so both suites use the copy from the v2 branch, which retries the release download.
+TEST_HARNESS_DOWNLOADER_URL=https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/v2/downloader/run.sh
+TEST_HARNESS_DOWNLOADER=build/sdk-test-harness-downloader.sh
+
 build-contract-tests:
 	@cd contract-tests && ../gradlew --no-daemon -s assembleDebug -PdisablePreDex
 
@@ -13,16 +18,18 @@ start-emulator:
 start-contract-test-service:
 	@scripts/start-test-service.sh
 
+$(TEST_HARNESS_DOWNLOADER):
+	@mkdir -p $(dir $@)
+	@curl $${GITHUB_TOKEN:+ -H "Authorization: Token $${GITHUB_TOKEN}"} \
+      --fail -sS -L --retry 5 --retry-delay 2 \
+      -o $@ $(TEST_HARNESS_DOWNLOADER_URL)
+
 # Note that only the last version of the tests have the stop-service-at-end flag set, so the contract test service will be stopped after the tests are run.
-run-contract-tests:
+run-contract-tests: $(TEST_HARNESS_DOWNLOADER)
 	@echo "Running SDK contract test v2..."
-	@curl $${GITHUB_TOKEN:+ -H "Authorization: Token $${GITHUB_TOKEN}"} \
-      -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/v2/downloader/run.sh \
-      | VERSION=v2 PARAMS="-url http://localhost:8001 -host 10.0.2.2 -debug -skip-from $(SUPPRESSION_FILE) $(TEST_HARNESS_PARAMS_V2)" sh
+	@VERSION=v2 PARAMS="-url http://localhost:8001 -host 10.0.2.2 -debug -skip-from $(SUPPRESSION_FILE) $(TEST_HARNESS_PARAMS_V2)" sh $(TEST_HARNESS_DOWNLOADER)
 	@echo "Running SDK contract test v3..."
-	@curl $${GITHUB_TOKEN:+ -H "Authorization: Token $${GITHUB_TOKEN}"} \
-      -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/v3.1.0-alpha.6/downloader/run.sh \
-      | VERSION=v3.1.0-alpha.6 PARAMS="-url http://localhost:8001 -host 10.0.2.2 -debug -stop-service-at-end -skip-from $(SUPPRESSION_FILE_FDV2) $(TEST_HARNESS_PARAMS_V3)" sh
+	@VERSION=v3.1.0-alpha.6 PARAMS="-url http://localhost:8001 -host 10.0.2.2 -debug -stop-service-at-end -skip-from $(SUPPRESSION_FILE_FDV2) $(TEST_HARNESS_PARAMS_V3)" sh $(TEST_HARNESS_DOWNLOADER)
 
 contract-tests: build-contract-tests start-emulator start-contract-test-service run-contract-tests
 

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/StateDebounceManagerTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/StateDebounceManagerTest.java
@@ -144,15 +144,21 @@ public class StateDebounceManagerTest {
     }
 
     @Test
-    public void closeCancelsPendingTimer() throws InterruptedException {
+    public void closeCancelsPendingTimer() {
+        // Uses a manually-driven executor instead of Thread.sleep so the test is deterministic:
+        // sleeping for a fraction of the debounce window and expecting close() to win the race
+        // is flaky on loaded CI runners, where the short sleep can overshoot the window and let
+        // the timer fire first.
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr = new StateDebounceManager(
+                true, true, manualExecutor, TEST_DEBOUNCE_MS, callCount::incrementAndGet);
 
         mgr.setNetworkAvailable(false);
-        Thread.sleep(TEST_DEBOUNCE_MS / 3);
         mgr.close();
 
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        assertEquals("close should cancel the scheduled timer", 1, manualExecutor.cancelledCount());
+        manualExecutor.runPendingTasks();
         assertEquals("pending timer should be cancelled on close", 0, callCount.get());
     }
 
@@ -341,15 +347,19 @@ public class StateDebounceManagerTest {
     // ==== reset() (CONNMODE 3.5.6 — identify bypasses debounce) ====
 
     @Test
-    public void resetCancelsPendingTimer() throws InterruptedException {
+    public void resetCancelsPendingTimer() {
+        // Manually-driven executor for the same reason as closeCancelsPendingTimer: reset() must
+        // win against the pending timer, which a wall-clock sleep cannot guarantee.
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr = new StateDebounceManager(
+                true, true, manualExecutor, TEST_DEBOUNCE_MS, callCount::incrementAndGet);
 
         mgr.setNetworkAvailable(false);
-        Thread.sleep(TEST_DEBOUNCE_MS / 3);
         mgr.reset(true, true);
 
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        assertEquals("reset should cancel the scheduled timer", 1, manualExecutor.cancelledCount());
+        manualExecutor.runPendingTasks();
         assertEquals("reset should cancel the pending timer", 0, callCount.get());
 
         mgr.close();


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Comes out of a review of every `Build and Test` run (PR + `main`) over the last three months, including all attempts of re-run builds. The FDv2 `OutOfMemoryError` flakes found by that review are being fixed separately in #384 and are deliberately untouched here.

**Describe the solution you've provided**

Two independent flake sources, both outside the SDK's production code.

`StateDebounceManagerTest.closeCancelsPendingTimer` scheduled a debounce timer, slept for a fraction of the window, and expected `close()` to win the race. On a loaded runner the sleep overshoots the window, the timer fires first, and the test fails. It now drives the timer through the existing `ManualTaskExecutor`, so cancellation is observed directly rather than inferred from wall-clock ordering, and additionally asserts that the scheduled task really was cancelled. `resetCancelsPendingTimer` had the identical shape and gets the same treatment. Two sibling tests were already converted this way in earlier fixes; these were missed.

The contract test step fetched the harness downloader with `curl -s ... | sh`. Beyond having no retry, that pipeline is silently fatal in the wrong direction: a failed fetch feeds `sh` an empty script, which exits 0, so the contract tests would be skipped and the build would go green. The downloader is now fetched to a file with `--fail` and retries, and run from there, so a fetch failure fails the build. Both suites share that one copy, taken from the branch whose downloader retries the release download — the script is version-agnostic, `VERSION` still selects which harness binary each suite fetches, which is what fixes the observed `Download failed` failures on the v3 run.

**Describe alternatives you've considered**

Retrying the whole contract-test step would also mask genuine failures, and re-running the suite after the emulator has booted is expensive. Pinning `VERSION=v2` to an exact release (as the v3 line already does) is a separate recommendation: the floating tag makes contract results non-reproducible and has already produced a red-then-green build with no code change, but changing it is a process decision rather than a flake fix, so it is not part of this PR.

**Additional context**

Verified with `:launchdarkly-android-client-sdk:test` (full unit test suite) plus repeated `--rerun-tasks` runs of the changed class, and `:launchdarkly-android-client-sdk:lint`. The Makefile change was exercised both ways: a successful download and run of the harness, and a deliberately bad downloader URL, which now aborts the target instead of quietly skipping the tests.


Link to Devin session: https://app.devin.ai/sessions/fb9541c6fa994866a832460742c89682
Requested by: @kinyoklion