### PR TITLE
chore: use valueOf instead of deprecated boxing constructors in FlagTest

### DIFF
--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/FlagTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/FlagTest.java
@@ -156,7 +156,7 @@ public class FlagTest {
     public void variationIsDeserialized() {
         final String jsonStr = "{\"version\": 99, \"variation\": 2}";
         final Flag r = gson.fromJson(jsonStr, Flag.class);
-        assertEquals(new Integer(2), r.getVariation());
+        assertEquals(Integer.valueOf(2), r.getVariation());
     }
 
     @Test
@@ -243,12 +243,12 @@ public class FlagTest {
     public void debugEventsUntilDateIsDeserialized() {
         final String jsonStr = "{\"version\": 99, \"debugEventsUntilDate\": 12345}";
         final Flag r = gson.fromJson(jsonStr, Flag.class);
-        assertEquals(new Long(12345L), r.getDebugEventsUntilDate());
+        assertEquals(Long.valueOf(12345L), r.getDebugEventsUntilDate());
 
         // Test long sized number
         final String jsonStrl = "{\"version\": 99, \"debugEventsUntilDate\": 2500000000}";
         final Flag rl = gson.fromJson(jsonStrl, Flag.class);
-        assertEquals(new Long(2500000000L), rl.getDebugEventsUntilDate());
+        assertEquals(Long.valueOf(2500000000L), rl.getDebugEventsUntilDate());
     }
 
     @Test


### PR DESCRIPTION
## Why

The build compiles with `-Xlint:deprecation`, so three `new Integer(...)` / `new Long(...)` calls in `FlagTest` print warnings on every CI run:

```
FlagTest.java:159: warning: [deprecation] Integer(int) in Integer has been deprecated
FlagTest.java:246: warning: [deprecation] Long(long) in Long has been deprecated
FlagTest.java:251: warning: [deprecation] Long(long) in Long has been deprecated
```

`valueOf` is the direct replacement. Overload resolution is unchanged — the arguments are still boxed types, so these remain `assertEquals(Object, Object)` calls comparing the same values.

## Test plan

- [x] `FlagTest` passes
- [x] Recompiled the unit test source set and confirmed these three warnings are gone

Nothing shipped changes, so this is `chore` and should not cut a release.

Note: CI on this branch may hit the `FDv2DataSourceTest` flake until #390 merges, since this branch is on current `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Test-only cleanup** in `FlagTest`: three `assertEquals` expectations now use `Integer.valueOf(2)` and `Long.valueOf(...)` instead of deprecated `new Integer(...)` / `new Long(...)`, so `-Xlint:deprecation` no longer warns on those lines during CI.
> 
> Behavior is unchanged—the same boxed values are compared via `assertEquals(Object, Object)` overload resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a050514e1cf74e10b01696c8ad596ded50be0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->