### PR TITLE
feat: add registerPlugin so a plugin can be added after the client starts

### DIFF
--- a/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientPluginsTest.java
+++ b/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientPluginsTest.java
@@ -2,6 +2,7 @@ package com.launchdarkly.sdk.android;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import android.app.Application;
@@ -178,6 +179,81 @@ public class LDClientPluginsTest {
     }
 
     @Test
+    public void configuredPluginThatFailsToRegisterContributesNoHooks() throws Exception {
+        MockHook testHook = new MockHook();
+        MockPlugin testPlugin = new MockPlugin(Collections.singletonList(testHook), false, true);
+
+        try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(List.of(testPlugin)), ldContext, 1)) {
+            assertEquals(1, testPlugin.registerCalls.size());
+
+            // The hooks go live only once register has succeeded, so this plugin contributes none.
+            ldClient.boolVariation("test-flag", false);
+            assertEquals(0, testHook.beforeEvaluationCalls.size());
+            assertEquals(0, testHook.afterEvaluationCalls.size());
+
+            assertEquals(1, testPlugin.onPluginsReadyCalls.size());
+            RegistrationCompleteResult result =
+                    (RegistrationCompleteResult) testPlugin.onPluginsReadyCalls.get(0).get("result");
+            assertTrue(result instanceof RegistrationCompleteResult.Failure);
+
+            logging.assertErrorLogged("Exception thrown registering plugin");
+        }
+    }
+
+    @Test
+    public void configuredPluginWhoseGetHooksThrowsIsNotRegistered() throws Exception {
+        MockHook testHook = new MockHook();
+        MockPlugin testPlugin = new MockPlugin(Collections.singletonList(testHook), true, false);
+
+        try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(List.of(testPlugin)), ldContext, 1)) {
+            // The logged message says the plugin will not be registered, and it is not.
+            assertEquals(0, testPlugin.registerCalls.size());
+
+            ldClient.boolVariation("test-flag", false);
+            assertEquals(0, testHook.beforeEvaluationCalls.size());
+
+            logging.assertErrorLogged("Unable to get hooks");
+        }
+    }
+
+    @Test
+    public void configuredPluginHooksDoNotObserveAnotherPluginsRegister() throws Exception {
+        MockHook firstHook = new MockHook();
+        MockPlugin firstPlugin = new MockPlugin(Collections.singletonList(firstHook));
+        // Registers after the first plugin, and evaluates a flag while doing so.
+        EvaluateOnRegisterPlugin secondPlugin = new EvaluateOnRegisterPlugin(new MockHook());
+
+        try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(List.of(firstPlugin, secondPlugin)), ldContext, 1)) {
+            assertEquals(1, secondPlugin.registerCalls.size());
+
+            // Hooks are activated only once every plugin has registered, so the first plugin's hooks
+            // did not observe the evaluation the second plugin made while registering.
+            assertEquals(0, firstHook.beforeEvaluationCalls.size());
+
+            ldClient.boolVariation("test-flag", false);
+            assertEquals(1, firstHook.beforeEvaluationCalls.size());
+
+            logging.assertNoErrorsLogged();
+        }
+    }
+
+    @Test
+    public void configuredPluginFailureDoesNotPreventOtherPlugins() throws Exception {
+        MockHook goodHook = new MockHook();
+        MockPlugin badPlugin = new MockPlugin(Collections.emptyList(), false, true);
+        MockPlugin goodPlugin = new MockPlugin(Collections.singletonList(goodHook));
+
+        try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(List.of(badPlugin, goodPlugin)), ldContext, 1)) {
+            assertEquals(1, goodPlugin.registerCalls.size());
+
+            ldClient.boolVariation("test-flag", false);
+            assertEquals(1, goodHook.beforeEvaluationCalls.size());
+
+            logging.assertErrorLogged("Exception thrown registering plugin");
+        }
+    }
+
+    @Test
     public void registerPluginPassesClientAndEnvironmentMetadata() throws Exception {
         MockPlugin testPlugin = new MockPlugin(Collections.emptyList());
 
@@ -224,23 +300,23 @@ public class LDClientPluginsTest {
     }
 
     @Test
-    public void registerPluginRunsTheRegisteringPluginsOwnHooks() throws Exception {
+    public void registerPluginDoesNotRunTheRegisteringPluginsOwnHooks() throws Exception {
         MockHook testHook = new MockHook();
         EvaluateOnRegisterPlugin testPlugin = new EvaluateOnRegisterPlugin(testHook);
 
         try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(null), ldContext, 1)) {
             ldClient.registerPlugin(testPlugin);
 
-            // The plugin evaluated a flag from inside register, and its own hooks were already live,
-            // as they would have been for a plugin configured up front.
+            // The plugin evaluated a flag from inside register, but its own hooks only go live once
+            // register has returned, as they do for a plugin configured up front.
             assertEquals(1, testPlugin.registerCalls.size());
+            assertEquals(0, testHook.beforeEvaluationCalls.size());
+            assertEquals(0, testHook.afterEvaluationCalls.size());
+
+            // They do run for evaluations made once registration has completed.
+            ldClient.boolVariation("test-flag", false);
             assertEquals(1, testHook.beforeEvaluationCalls.size());
             assertEquals(1, testHook.afterEvaluationCalls.size());
-
-            // And they keep running for evaluations made after registration.
-            ldClient.boolVariation("test-flag", false);
-            assertEquals(2, testHook.beforeEvaluationCalls.size());
-            assertEquals(2, testHook.afterEvaluationCalls.size());
 
             logging.assertNoErrorsLogged();
         }
@@ -290,11 +366,11 @@ public class LDClientPluginsTest {
             ldClient.registerPlugin(testPlugin);
             assertEquals(1, testPlugin.registerCalls.size());
 
-            // The hooks were already live when register threw, so they stay live, as they do for a
-            // plugin configured up front whose register throws.
+            // A plugin that failed to register contributes no hooks, as one configured up front
+            // whose register throws now also does not.
             ldClient.boolVariation("test-flag", false);
-            assertEquals(1, testHook.beforeEvaluationCalls.size());
-            assertEquals(1, testHook.afterEvaluationCalls.size());
+            assertEquals(0, testHook.beforeEvaluationCalls.size());
+            assertEquals(0, testHook.afterEvaluationCalls.size());
 
             // The failure is reported in the log alone, since this path does not call
             // onPluginsReady.

--- a/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientPluginsTest.java
+++ b/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientPluginsTest.java
@@ -224,22 +224,23 @@ public class LDClientPluginsTest {
     }
 
     @Test
-    public void registerPluginDoesNotRunTheRegisteringPluginsOwnHooks() throws Exception {
+    public void registerPluginRunsTheRegisteringPluginsOwnHooks() throws Exception {
         MockHook testHook = new MockHook();
         EvaluateOnRegisterPlugin testPlugin = new EvaluateOnRegisterPlugin(testHook);
 
         try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(null), ldContext, 1)) {
             ldClient.registerPlugin(testPlugin);
 
-            // The plugin evaluated a flag from inside register, but its own hooks were not live yet.
+            // The plugin evaluated a flag from inside register, and its own hooks were already live,
+            // as they would have been for a plugin configured up front.
             assertEquals(1, testPlugin.registerCalls.size());
-            assertEquals(0, testHook.beforeEvaluationCalls.size());
-            assertEquals(0, testHook.afterEvaluationCalls.size());
-
-            // They do run for evaluations made once registration has completed.
-            ldClient.boolVariation("test-flag", false);
             assertEquals(1, testHook.beforeEvaluationCalls.size());
             assertEquals(1, testHook.afterEvaluationCalls.size());
+
+            // And they keep running for evaluations made after registration.
+            ldClient.boolVariation("test-flag", false);
+            assertEquals(2, testHook.beforeEvaluationCalls.size());
+            assertEquals(2, testHook.afterEvaluationCalls.size());
 
             logging.assertNoErrorsLogged();
         }
@@ -289,10 +290,11 @@ public class LDClientPluginsTest {
             ldClient.registerPlugin(testPlugin);
             assertEquals(1, testPlugin.registerCalls.size());
 
-            // A plugin that failed to register contributes no hooks.
+            // The hooks were already live when register threw, so they stay live, as they do for a
+            // plugin configured up front whose register throws.
             ldClient.boolVariation("test-flag", false);
-            assertEquals(0, testHook.beforeEvaluationCalls.size());
-            assertEquals(0, testHook.afterEvaluationCalls.size());
+            assertEquals(1, testHook.beforeEvaluationCalls.size());
+            assertEquals(1, testHook.afterEvaluationCalls.size());
 
             // The failure is reported in the log alone, since this path does not call
             // onPluginsReady.

--- a/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientPluginsTest.java
+++ b/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientPluginsTest.java
@@ -1,6 +1,8 @@
 package com.launchdarkly.sdk.android;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import android.app.Application;
@@ -18,6 +20,7 @@ import com.launchdarkly.sdk.android.integrations.IdentifySeriesContext;
 import com.launchdarkly.sdk.android.integrations.IdentifySeriesResult;
 import com.launchdarkly.sdk.android.integrations.Plugin;
 import com.launchdarkly.sdk.android.integrations.PluginMetadata;
+import com.launchdarkly.sdk.android.integrations.RegistrationCompleteResult;
 import com.launchdarkly.sdk.android.integrations.TrackSeriesContext;
 
 import org.junit.Before;
@@ -175,6 +178,174 @@ public class LDClientPluginsTest {
         }
     }
 
+    @Test
+    public void registerPluginPassesClientAndEnvironmentMetadata() throws Exception {
+        MockPlugin testPlugin = new MockPlugin(Collections.emptyList());
+
+        try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(null), ldContext, 1)) {
+            ldClient.registerPlugin(testPlugin);
+
+            assertEquals(1, testPlugin.getHooksCalls.size());
+            assertEquals(1, testPlugin.registerCalls.size());
+            assertEquals(ldClient, testPlugin.registerCalls.get(0).get("client"));
+
+            EnvironmentMetadata metadata = (EnvironmentMetadata) testPlugin.registerCalls.get(0).get("environmentMetadata");
+            assertEquals(mobileKey, metadata.getCredential());
+            assertEquals("AndroidClient", metadata.getSdkMetadata().getName());
+
+            // The same environment description a plugin configured up front would have been given.
+            assertEquals(metadata, testPlugin.getHooksCalls.get(0).get("environmentMetadata"));
+
+            logging.assertNoErrorsLogged();
+        }
+    }
+
+    @Test
+    public void registerPluginActivatesBundledHooks() throws Exception {
+        MockHook testHook = new MockHook();
+        MockPlugin testPlugin = new MockPlugin(Collections.singletonList(testHook));
+
+        try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(null), ldContext, 1)) {
+            ldClient.registerPlugin(testPlugin);
+
+            ldClient.boolVariation("test-flag", false);
+            assertEquals(1, testHook.beforeEvaluationCalls.size());
+            assertEquals(1, testHook.afterEvaluationCalls.size());
+
+            ldClient.identify(LDContext.create("newUserKey")).get();
+            // Only the identify made after registration: the implicit one during init predates the plugin.
+            assertEquals(1, testHook.beforeIdentifyCalls.size());
+            assertEquals(1, testHook.afterIdentifyCalls.size());
+
+            ldClient.track("test-event");
+            assertEquals(1, testHook.afterTrackCalls.size());
+
+            logging.assertNoErrorsLogged();
+        }
+    }
+
+    @Test
+    public void registerPluginDoesNotRunTheRegisteringPluginsOwnHooks() throws Exception {
+        MockHook testHook = new MockHook();
+        EvaluateOnRegisterPlugin testPlugin = new EvaluateOnRegisterPlugin(testHook);
+
+        try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(null), ldContext, 1)) {
+            ldClient.registerPlugin(testPlugin);
+
+            // The plugin evaluated a flag from inside register, but its own hooks were not live yet.
+            assertEquals(1, testPlugin.registerCalls.size());
+            assertEquals(0, testHook.beforeEvaluationCalls.size());
+            assertEquals(0, testHook.afterEvaluationCalls.size());
+
+            // They do run for evaluations made once registration has completed.
+            ldClient.boolVariation("test-flag", false);
+            assertEquals(1, testHook.beforeEvaluationCalls.size());
+            assertEquals(1, testHook.afterEvaluationCalls.size());
+
+            logging.assertNoErrorsLogged();
+        }
+    }
+
+    @Test
+    public void registerPluginReportsSuccessToOnPluginsReady() throws Exception {
+        MockPlugin testPlugin = new MockPlugin(Collections.emptyList());
+
+        try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(null), ldContext, 1)) {
+            ldClient.registerPlugin(testPlugin);
+
+            assertEquals(1, testPlugin.onPluginsReadyCalls.size());
+            assertEquals(RegistrationCompleteResult.success(), testPlugin.onPluginsReadyCalls.get(0).get("result"));
+
+            EnvironmentMetadata metadata = (EnvironmentMetadata) testPlugin.onPluginsReadyCalls.get(0).get("environmentMetadata");
+            assertEquals(mobileKey, metadata.getCredential());
+
+            logging.assertNoErrorsLogged();
+        }
+    }
+
+    @Test
+    public void registerPluginDoesNotRegisterPluginWhoseGetHooksThrows() throws Exception {
+        MockHook testHook = new MockHook();
+        MockPlugin testPlugin = new MockPlugin(Collections.singletonList(testHook), true, false);
+
+        try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(null), ldContext, 1)) {
+            ldClient.registerPlugin(testPlugin);
+
+            assertEquals(0, testPlugin.registerCalls.size());
+            assertEquals(0, testPlugin.onPluginsReadyCalls.size());
+
+            ldClient.boolVariation("test-flag", false);
+            assertEquals(0, testHook.beforeEvaluationCalls.size());
+
+            logging.assertErrorLogged("Unable to get hooks");
+        }
+    }
+
+    @Test
+    public void registerPluginToleratesRegisterThrowing() throws Exception {
+        MockHook testHook = new MockHook();
+        MockPlugin testPlugin = new MockPlugin(Collections.singletonList(testHook), false, true);
+
+        try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(null), ldContext, 1)) {
+            // The exception is logged rather than propagated.
+            ldClient.registerPlugin(testPlugin);
+            assertEquals(1, testPlugin.registerCalls.size());
+
+            // A plugin that failed to register contributes no hooks.
+            ldClient.boolVariation("test-flag", false);
+            assertEquals(0, testHook.beforeEvaluationCalls.size());
+            assertEquals(0, testHook.afterEvaluationCalls.size());
+
+            assertEquals(1, testPlugin.onPluginsReadyCalls.size());
+            RegistrationCompleteResult result =
+                    (RegistrationCompleteResult) testPlugin.onPluginsReadyCalls.get(0).get("result");
+            assertTrue(result instanceof RegistrationCompleteResult.Failure);
+            List<RegistrationCompleteResult.Failure.PluginFailure> failures =
+                    ((RegistrationCompleteResult.Failure) result).getFailures();
+            assertEquals(1, failures.size());
+            assertEquals("mock-plugin-name", failures.get(0).getPluginName());
+
+            logging.assertErrorLogged("Exception thrown registering plugin");
+        }
+    }
+
+    @Test
+    public void registerPluginRejectsNullPlugin() throws Exception {
+        try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(null), ldContext, 1)) {
+            assertThrows(NullPointerException.class, () -> ldClient.registerPlugin(null));
+        }
+    }
+
+    @Test
+    public void registerPluginAppliesOnlyToTheClientItIsCalledOn() throws Exception {
+        MockHook testHook = new MockHook();
+        MockPlugin testPlugin = new MockPlugin(Collections.singletonList(testHook));
+
+        LDConfig config = new LDConfig.Builder(LDConfig.Builder.AutoEnvAttributes.Disabled)
+                .mobileKey(mobileKey)
+                .secondaryMobileKeys(Map.of("secondaryEnvironment", secondaryMobileKey))
+                .offline(true)
+                .events(Components.noEvents())
+                .logAdapter(logging.logAdapter)
+                .build();
+
+        try (LDClient ldClient = LDClient.init(application, config, ldContext, 10)) {
+            ldClient.registerPlugin(testPlugin);
+
+            assertEquals(1, testPlugin.registerCalls.size());
+            assertEquals(ldClient, testPlugin.registerCalls.get(0).get("client"));
+
+            ldClient.boolVariation("test-flag", false);
+            assertEquals(1, testHook.beforeEvaluationCalls.size());
+
+            // The other environment has its own client, which this plugin was not registered with.
+            LDClient.getForMobileKey("secondaryEnvironment").boolVariation("test-flag", false);
+            assertEquals(1, testHook.beforeEvaluationCalls.size());
+
+            logging.assertNoErrorsLogged();
+        }
+    }
+
     private LDConfig makeOfflineConfig(List<Plugin> plugins) {
         LDConfig.Builder builder = new LDConfig.Builder(LDConfig.Builder.AutoEnvAttributes.Disabled)
                 .mobileKey(mobileKey)
@@ -192,12 +363,21 @@ public class LDClientPluginsTest {
     private static class MockPlugin extends Plugin {
 
         private final List<Hook> hooks;
+        private final boolean throwOnGetHooks;
+        private final boolean throwOnRegister;
 
         public final List<Map<String, Object>> getHooksCalls = new ArrayList<>();
         public final List<Map<String, Object>> registerCalls = new ArrayList<>();
+        public final List<Map<String, Object>> onPluginsReadyCalls = new ArrayList<>();
 
         public MockPlugin(List<Hook> hooks) {
+            this(hooks, false, false);
+        }
+
+        public MockPlugin(List<Hook> hooks, boolean throwOnGetHooks, boolean throwOnRegister) {
             this.hooks = hooks;
+            this.throwOnGetHooks = throwOnGetHooks;
+            this.throwOnRegister = throwOnRegister;
         }
 
         @NonNull
@@ -230,6 +410,9 @@ public class LDClientPluginsTest {
                     "client", client,
                     "environmentMetadata", metadata
             ));
+            if (throwOnRegister) {
+                throw new RuntimeException("register failed for mock-plugin-name");
+            }
         }
 
         @NonNull
@@ -238,7 +421,57 @@ public class LDClientPluginsTest {
             getHooksCalls.add(Map.of(
                     "environmentMetadata", metadata
             ));
+            if (throwOnGetHooks) {
+                throw new RuntimeException("getHooks failed for mock-plugin-name");
+            }
             return this.hooks;
+        }
+
+        @Override
+        public void onPluginsReady(RegistrationCompleteResult result, EnvironmentMetadata metadata) {
+            onPluginsReadyCalls.add(Map.of(
+                    "result", result,
+                    "environmentMetadata", metadata
+            ));
+        }
+    }
+
+    /**
+     * Evaluates a flag from inside {@code register}, so a test can tell whether the plugin's own hooks were live at
+     * that point.
+     */
+    private static class EvaluateOnRegisterPlugin extends Plugin {
+
+        private final Hook hook;
+
+        public final List<Map<String, Object>> registerCalls = new ArrayList<>();
+
+        public EvaluateOnRegisterPlugin(Hook hook) {
+            this.hook = hook;
+        }
+
+        @NonNull
+        @Override
+        public PluginMetadata getMetadata() {
+            return new PluginMetadata() {
+                @NonNull
+                @Override
+                public String getName() {
+                    return "evaluate-on-register-plugin";
+                }
+            };
+        }
+
+        @Override
+        public void register(LDClient client, EnvironmentMetadata metadata) {
+            registerCalls.add(Map.of("client", client, "environmentMetadata", metadata));
+            client.boolVariation("test-flag", false);
+        }
+
+        @NonNull
+        @Override
+        public List<Hook> getHooks(EnvironmentMetadata metadata) {
+            return Collections.singletonList(hook);
         }
     }
 

--- a/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientPluginsTest.java
+++ b/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientPluginsTest.java
@@ -2,7 +2,6 @@ package com.launchdarkly.sdk.android;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import android.app.Application;
@@ -247,17 +246,16 @@ public class LDClientPluginsTest {
     }
 
     @Test
-    public void registerPluginReportsSuccessToOnPluginsReady() throws Exception {
+    public void registerPluginDoesNotCallOnPluginsReady() throws Exception {
         MockPlugin testPlugin = new MockPlugin(Collections.emptyList());
 
         try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(null), ldContext, 1)) {
             ldClient.registerPlugin(testPlugin);
 
-            assertEquals(1, testPlugin.onPluginsReadyCalls.size());
-            assertEquals(RegistrationCompleteResult.success(), testPlugin.onPluginsReadyCalls.get(0).get("result"));
-
-            EnvironmentMetadata metadata = (EnvironmentMetadata) testPlugin.onPluginsReadyCalls.get(0).get("environmentMetadata");
-            assertEquals(mobileKey, metadata.getCredential());
+            // onPluginsReady reports on a batch of plugins registered together, so registering a
+            // single plugin on its own has nothing to report and does not call it.
+            assertEquals(1, testPlugin.registerCalls.size());
+            assertEquals(0, testPlugin.onPluginsReadyCalls.size());
 
             logging.assertNoErrorsLogged();
         }
@@ -296,14 +294,9 @@ public class LDClientPluginsTest {
             assertEquals(0, testHook.beforeEvaluationCalls.size());
             assertEquals(0, testHook.afterEvaluationCalls.size());
 
-            assertEquals(1, testPlugin.onPluginsReadyCalls.size());
-            RegistrationCompleteResult result =
-                    (RegistrationCompleteResult) testPlugin.onPluginsReadyCalls.get(0).get("result");
-            assertTrue(result instanceof RegistrationCompleteResult.Failure);
-            List<RegistrationCompleteResult.Failure.PluginFailure> failures =
-                    ((RegistrationCompleteResult.Failure) result).getFailures();
-            assertEquals(1, failures.size());
-            assertEquals("mock-plugin-name", failures.get(0).getPluginName());
+            // The failure is reported in the log alone, since this path does not call
+            // onPluginsReady.
+            assertEquals(0, testPlugin.onPluginsReadyCalls.size());
 
             logging.assertErrorLogged("Exception thrown registering plugin");
         }
@@ -427,6 +420,9 @@ public class LDClientPluginsTest {
             return this.hooks;
         }
 
+        // Overridden despite the deprecation so tests can assert both that the configured-plugin
+        // path still calls it and that registerPlugin does not.
+        @SuppressWarnings("deprecation")
         @Override
         public void onPluginsReady(RegistrationCompleteResult result, EnvironmentMetadata metadata) {
             onPluginsReadyCalls.add(Map.of(

--- a/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientPluginsTest.java
+++ b/launchdarkly-android-client-sdk/src/androidTest/java/com/launchdarkly/sdk/android/LDClientPluginsTest.java
@@ -179,17 +179,17 @@ public class LDClientPluginsTest {
     }
 
     @Test
-    public void configuredPluginThatFailsToRegisterContributesNoHooks() throws Exception {
+    public void configuredPluginThatFailsToRegisterKeepsItsHooks() throws Exception {
         MockHook testHook = new MockHook();
         MockPlugin testPlugin = new MockPlugin(Collections.singletonList(testHook), false, true);
 
         try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(List.of(testPlugin)), ldContext, 1)) {
             assertEquals(1, testPlugin.registerCalls.size());
 
-            // The hooks go live only once register has succeeded, so this plugin contributes none.
+            // The hooks were already live when register threw, so they stay live.
             ldClient.boolVariation("test-flag", false);
-            assertEquals(0, testHook.beforeEvaluationCalls.size());
-            assertEquals(0, testHook.afterEvaluationCalls.size());
+            assertEquals(1, testHook.beforeEvaluationCalls.size());
+            assertEquals(1, testHook.afterEvaluationCalls.size());
 
             assertEquals(1, testPlugin.onPluginsReadyCalls.size());
             RegistrationCompleteResult result =
@@ -217,7 +217,7 @@ public class LDClientPluginsTest {
     }
 
     @Test
-    public void configuredPluginHooksDoNotObserveAnotherPluginsRegister() throws Exception {
+    public void configuredPluginHooksObserveAnotherPluginsRegister() throws Exception {
         MockHook firstHook = new MockHook();
         MockPlugin firstPlugin = new MockPlugin(Collections.singletonList(firstHook));
         // Registers after the first plugin, and evaluates a flag while doing so.
@@ -226,12 +226,12 @@ public class LDClientPluginsTest {
         try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(List.of(firstPlugin, secondPlugin)), ldContext, 1)) {
             assertEquals(1, secondPlugin.registerCalls.size());
 
-            // Hooks are activated only once every plugin has registered, so the first plugin's hooks
-            // did not observe the evaluation the second plugin made while registering.
-            assertEquals(0, firstHook.beforeEvaluationCalls.size());
+            // Hooks are activated before any plugin registers, so the first plugin's hooks observed
+            // the evaluation the second plugin made while registering.
+            assertEquals(1, firstHook.beforeEvaluationCalls.size());
 
             ldClient.boolVariation("test-flag", false);
-            assertEquals(1, firstHook.beforeEvaluationCalls.size());
+            assertEquals(2, firstHook.beforeEvaluationCalls.size());
 
             logging.assertNoErrorsLogged();
         }
@@ -300,23 +300,23 @@ public class LDClientPluginsTest {
     }
 
     @Test
-    public void registerPluginDoesNotRunTheRegisteringPluginsOwnHooks() throws Exception {
+    public void registerPluginRunsTheRegisteringPluginsOwnHooks() throws Exception {
         MockHook testHook = new MockHook();
         EvaluateOnRegisterPlugin testPlugin = new EvaluateOnRegisterPlugin(testHook);
 
         try (LDClient ldClient = LDClient.init(application, makeOfflineConfig(null), ldContext, 1)) {
             ldClient.registerPlugin(testPlugin);
 
-            // The plugin evaluated a flag from inside register, but its own hooks only go live once
-            // register has returned, as they do for a plugin configured up front.
+            // The plugin evaluated a flag from inside register, and its own hooks were already live
+            // by then, as they are for a plugin configured up front.
             assertEquals(1, testPlugin.registerCalls.size());
-            assertEquals(0, testHook.beforeEvaluationCalls.size());
-            assertEquals(0, testHook.afterEvaluationCalls.size());
-
-            // They do run for evaluations made once registration has completed.
-            ldClient.boolVariation("test-flag", false);
             assertEquals(1, testHook.beforeEvaluationCalls.size());
             assertEquals(1, testHook.afterEvaluationCalls.size());
+
+            // And they keep running for evaluations made after registration.
+            ldClient.boolVariation("test-flag", false);
+            assertEquals(2, testHook.beforeEvaluationCalls.size());
+            assertEquals(2, testHook.afterEvaluationCalls.size());
 
             logging.assertNoErrorsLogged();
         }
@@ -366,11 +366,11 @@ public class LDClientPluginsTest {
             ldClient.registerPlugin(testPlugin);
             assertEquals(1, testPlugin.registerCalls.size());
 
-            // A plugin that failed to register contributes no hooks, as one configured up front
-            // whose register throws now also does not.
+            // The hooks were already live when register threw, so they stay live, as they do for a
+            // plugin configured up front whose register throws.
             ldClient.boolVariation("test-flag", false);
-            assertEquals(0, testHook.beforeEvaluationCalls.size());
-            assertEquals(0, testHook.afterEvaluationCalls.size());
+            assertEquals(1, testHook.beforeEvaluationCalls.size());
+            assertEquals(1, testHook.afterEvaluationCalls.size());
 
             // The failure is reported in the log alone, since this path does not call
             // onPluginsReady.

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/HookRunner.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/HookRunner.java
@@ -12,6 +12,7 @@ import com.launchdarkly.sdk.android.integrations.IdentifySeriesResult;
 import com.launchdarkly.sdk.android.integrations.TrackSeriesContext;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -73,8 +74,25 @@ public class HookRunner {
      * @param hook the hook to add
      */
     public synchronized void addHook(Hook hook) {
+        addHooks(Collections.singletonList(hook));
+    }
+
+    /**
+     * Adds hooks, which the next series to begin will run. A series already under way runs the hooks it began with.
+     * <p>
+     * The hooks become visible in a single step, so a series beginning on another thread runs either all of them or
+     * none of them, never part of the group. Adding the hooks a plugin contributes this way, rather than with repeated
+     * {@link #addHook(Hook)} calls, keeps hooks that are meant to work as a set from running half applied.
+     *
+     * @param hooksToAdd the hooks to add
+     */
+    public synchronized void addHooks(Collection<Hook> hooksToAdd) {
+        if (hooksToAdd.isEmpty()) {
+            return;
+        }
+
         List<Hook> updated = new ArrayList<>(hooks);
-        updated.add(hook);
+        updated.addAll(hooksToAdd);
         hooks = Collections.unmodifiableList(updated);
     }
 

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
@@ -225,31 +225,12 @@ public class LDClient implements LDClientInterface, Closeable {
             instances = newInstances;
         }
 
-        // after instances have been created, set up hooks for each plugin of the instance and call register
+        // after instances have been created, register each instance's plugins
         for (LDClient instance : createdInstances) {
             EnvironmentMetadata metadata = instance.environmentMetadata;
 
-            for (Plugin plugin : instance.plugins) {
-                // try is for each plugin so that if one plugin has an issue, the others will have an opportunity to be used
-                try {
-                    List<Hook> pluginHooks = plugin.getHooks(metadata);
-                    for (Hook hook : pluginHooks) {
-                        instance.hookRunner.addHook(hook);
-                    }
-                } catch (Exception e) {
-                    logger.error(PLUGIN_GET_HOOKS_ERROR, pluginName(plugin));
-                }
-            }
-
-            List<RegistrationCompleteResult.Failure.PluginFailure> pluginFailures = new ArrayList<>();
-            for (Plugin plugin : instance.plugins) {
-                try {
-                    plugin.register(instance, metadata);
-                } catch (Exception e) {
-                    pluginFailures.add(new RegistrationCompleteResult.Failure.PluginFailure(pluginName(plugin), e.getMessage(), e));
-                    logger.error(PLUGIN_REGISTER_ERROR, pluginName(plugin));
-                }
-            }
+            List<RegistrationCompleteResult.Failure.PluginFailure> pluginFailures =
+                    instance.registerPlugins(instance.plugins, metadata);
 
             RegistrationCompleteResult pluginsRegistrationResult = pluginFailures.isEmpty()
                     ? RegistrationCompleteResult.success()
@@ -905,27 +886,58 @@ public class LDClient implements LDClientInterface, Closeable {
             throw new NullPointerException("plugin must not be null");
         }
 
-        EnvironmentMetadata metadata = environmentMetadata;
+        registerPlugins(Collections.singletonList(plugin), environmentMetadata);
+    }
 
-        List<Hook> pluginHooks;
-        try {
-            pluginHooks = plugin.getHooks(metadata);
-        } catch (Exception e) {
-            logger.error(PLUGIN_GET_HOOKS_ERROR, pluginName(plugin));
-            return;
+    /**
+     * Registers each of {@code plugins} with this client, then activates the hooks contributed by
+     * those that registered successfully.
+     * <p>
+     * The hooks go live as the last step, once every plugin has registered, so that no plugin's
+     * hooks observe any plugin's {@link Plugin#register} call, and a plugin that failed to register
+     * contributes none. Shared by the plugins configured on {@link LDConfig} and by
+     * {@link #registerPlugin}, so that a plugin behaves the same however it was registered.
+     * <p>
+     * Exceptions from a plugin are logged rather than propagated, so that one failing plugin does
+     * not stop the others being registered.
+     *
+     * @param plugins  the plugins to register
+     * @param metadata the environment to describe to the plugins
+     * @return the failures to report to {@link Plugin#onPluginsReady}, empty if all succeeded
+     */
+    private List<RegistrationCompleteResult.Failure.PluginFailure> registerPlugins(
+            List<Plugin> plugins,
+            EnvironmentMetadata metadata
+    ) {
+        List<RegistrationCompleteResult.Failure.PluginFailure> failures = new ArrayList<>();
+        List<Hook> hooksToActivate = new ArrayList<>();
+
+        for (Plugin plugin : plugins) {
+            List<Hook> pluginHooks;
+            try {
+                pluginHooks = plugin.getHooks(metadata);
+            } catch (Exception e) {
+                logger.error(PLUGIN_GET_HOOKS_ERROR, pluginName(plugin));
+                failures.add(new RegistrationCompleteResult.Failure.PluginFailure(pluginName(plugin), e.getMessage(), e));
+                continue;
+            }
+
+            try {
+                plugin.register(this, metadata);
+            } catch (Exception e) {
+                logger.error(PLUGIN_REGISTER_ERROR, pluginName(plugin));
+                failures.add(new RegistrationCompleteResult.Failure.PluginFailure(pluginName(plugin), e.getMessage(), e));
+                continue;
+            }
+
+            hooksToActivate.addAll(pluginHooks);
         }
 
-        // The hooks go live before register is called, as they do for a plugin configured on
-        // LDConfig, so that a plugin behaves the same however it was registered.
-        for (Hook hook : pluginHooks) {
+        for (Hook hook : hooksToActivate) {
             hookRunner.addHook(hook);
         }
 
-        try {
-            plugin.register(this, metadata);
-        } catch (Exception e) {
-            logger.error(PLUGIN_REGISTER_ERROR, pluginName(plugin));
-        }
+        return failures;
     }
 
     /**

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
@@ -80,6 +80,7 @@ public class LDClient implements LDClientInterface, Closeable {
     // application may take on every redraw of a view.
     private final String mobileKeyHash;
     private List<Plugin> plugins;
+    private volatile EnvironmentMetadata environmentMetadata;
     // If 15 seconds or more is passed as a timeout to init, we will log a warning.
     private static final int EXCESSIVE_INIT_WAIT_SECONDS = 15;
 
@@ -133,7 +134,7 @@ public class LDClient implements LDClientInterface, Closeable {
         LDContext modifiedContext;
 
         // used for plugin registration after instances are created
-        final Map<LDClient, EnvironmentMetadata> instanceMetadatas = new HashMap<>();
+        final List<LDClient> createdInstances = new ArrayList<>();
 
         // Acquire the `initLock` to ensure that if `init()` is called multiple times, we will only
         // initialize the client(s) once.
@@ -201,7 +202,8 @@ public class LDClient implements LDClientInterface, Closeable {
                     }
 
                     // metadata created per environment since mobile key varies
-                    instanceMetadatas.put(instance, new EnvironmentMetadata(applicationInfo, sdkMetadata, mobileKey));
+                    instance.environmentMetadata = new EnvironmentMetadata(applicationInfo, sdkMetadata, mobileKey);
+                    createdInstances.add(instance);
 
                 } catch (LaunchDarklyException e) {
                     resultFuture.setException(e);
@@ -216,9 +218,8 @@ public class LDClient implements LDClientInterface, Closeable {
         }
 
         // after instances have been created, set up hooks for each plugin of the instance and call register
-        for (Map.Entry<LDClient, EnvironmentMetadata> entry : instanceMetadatas.entrySet()) {
-            LDClient instance = entry.getKey();
-            EnvironmentMetadata metadata = entry.getValue();
+        for (LDClient instance : createdInstances) {
+            EnvironmentMetadata metadata = instance.environmentMetadata;
 
             for (Plugin plugin : instance.plugins) {
                 // try is for each plugin so that if one plugin has an issue, the others will have an opportunity to be used
@@ -894,5 +895,58 @@ public class LDClient implements LDClientInterface, Closeable {
     @Override
     public void addHook(Hook hook) {
         hookRunner.addHook(hook);
+    }
+
+    @Override
+    public void registerPlugin(Plugin plugin) {
+        if (plugin == null) {
+            throw new NullPointerException("plugin must not be null");
+        }
+
+        EnvironmentMetadata metadata = environmentMetadata;
+
+        List<Hook> pluginHooks;
+        try {
+            pluginHooks = plugin.getHooks(metadata);
+        } catch (Exception e) {
+            logger.error("Exception thrown getting hooks for plugin " + pluginName(plugin) + ". Unable to get hooks, plugin will not be registered.");
+            return;
+        }
+
+        RegistrationCompleteResult result;
+        try {
+            plugin.register(this, metadata);
+            result = RegistrationCompleteResult.success();
+        } catch (Exception e) {
+            logger.error("Exception thrown registering plugin " + pluginName(plugin) + ".");
+            result = RegistrationCompleteResult.failure(Collections.singletonList(
+                    new RegistrationCompleteResult.Failure.PluginFailure(pluginName(plugin), e.getMessage(), e)));
+        }
+
+        // The hooks go live only once register has succeeded, so a plugin whose registration failed
+        // never contributes hooks, and a plugin's own hooks do not observe its register call.
+        if (result instanceof RegistrationCompleteResult.Success) {
+            for (Hook hook : pluginHooks) {
+                hookRunner.addHook(hook);
+            }
+        }
+
+        try {
+            plugin.onPluginsReady(result, metadata);
+        } catch (Exception e) {
+            logger.error("Exception thrown executing onPluginsReady for plugin " + pluginName(plugin) + ".");
+        }
+    }
+
+    /**
+     * Reads a plugin's name for a log message, tolerating a plugin whose metadata itself throws:
+     * otherwise reporting one failure would raise another out of the handler that reports it.
+     */
+    private String pluginName(Plugin plugin) {
+        try {
+            return plugin.getMetadata().getName();
+        } catch (Exception e) {
+            return "unknown";
+        }
     }
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
@@ -890,14 +890,15 @@ public class LDClient implements LDClientInterface, Closeable {
     }
 
     /**
-     * Registers each of {@code plugins} with this client, then activates the hooks contributed by
-     * those that registered successfully.
+     * Activates the hooks contributed by {@code plugins}, then registers each of those plugins with
+     * this client.
      * <p>
-     * The hooks go live as the last step, once every plugin has registered, so that no plugin's
-     * hooks observe any plugin's {@link Plugin#register} call, and a plugin that failed to register
-     * contributes none. Shared by the plugins configured on {@link LDConfig} and by
-     * {@link #registerPlugin}, so that a plugin behaves the same however it was registered.
+     * The hooks go live before any of the plugins registers, so that a plugin's hooks observe its own
+     * {@link Plugin#register} call and those of the plugins registered alongside it. Shared by the
+     * plugins configured on {@link LDConfig} and by {@link #registerPlugin}, so that a plugin behaves
+     * the same however it was registered.
      * <p>
+     * A plugin whose {@link Plugin#getHooks} throws contributes no hooks and is not registered.
      * Exceptions from a plugin are logged rather than propagated, so that one failing plugin does
      * not stop the others being registered.
      *
@@ -911,6 +912,7 @@ public class LDClient implements LDClientInterface, Closeable {
     ) {
         List<RegistrationCompleteResult.Failure.PluginFailure> failures = new ArrayList<>();
         List<Hook> hooksToActivate = new ArrayList<>();
+        List<Plugin> pluginsToRegister = new ArrayList<>();
 
         for (Plugin plugin : plugins) {
             List<Hook> pluginHooks;
@@ -922,20 +924,22 @@ public class LDClient implements LDClientInterface, Closeable {
                 continue;
             }
 
-            try {
-                plugin.register(this, metadata);
-            } catch (Exception e) {
-                logger.error(PLUGIN_REGISTER_ERROR, pluginName(plugin));
-                failures.add(new RegistrationCompleteResult.Failure.PluginFailure(pluginName(plugin), e.getMessage(), e));
-                continue;
-            }
-
             hooksToActivate.addAll(pluginHooks);
+            pluginsToRegister.add(plugin);
         }
 
         // Added in one step, so that a series beginning on another thread cannot run a plugin's hooks
         // half applied.
         hookRunner.addHooks(hooksToActivate);
+
+        for (Plugin plugin : pluginsToRegister) {
+            try {
+                plugin.register(this, metadata);
+            } catch (Exception e) {
+                logger.error(PLUGIN_REGISTER_ERROR, pluginName(plugin));
+                failures.add(new RegistrationCompleteResult.Failure.PluginFailure(pluginName(plugin), e.getMessage(), e));
+            }
+        }
 
         return failures;
     }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
@@ -933,9 +933,9 @@ public class LDClient implements LDClientInterface, Closeable {
             hooksToActivate.addAll(pluginHooks);
         }
 
-        for (Hook hook : hooksToActivate) {
-            hookRunner.addHook(hook);
-        }
+        // Added in one step, so that a series beginning on another thread cannot run a plugin's hooks
+        // half applied.
+        hookRunner.addHooks(hooksToActivate);
 
         return failures;
     }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
@@ -915,13 +915,14 @@ public class LDClient implements LDClientInterface, Closeable {
             return;
         }
 
+        // The hooks go live before register is called, as they do for a plugin configured on
+        // LDConfig, so that a plugin behaves the same however it was registered.
+        for (Hook hook : pluginHooks) {
+            hookRunner.addHook(hook);
+        }
+
         try {
             plugin.register(this, metadata);
-            // Adding the hooks only after register returns keeps them from observing the register
-            // call itself, and leaves a plugin whose registration threw contributing none.
-            for (Hook hook : pluginHooks) {
-                hookRunner.addHook(hook);
-            }
         } catch (Exception e) {
             logger.error(PLUGIN_REGISTER_ERROR, pluginName(plugin));
         }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClient.java
@@ -84,6 +84,14 @@ public class LDClient implements LDClientInterface, Closeable {
     // If 15 seconds or more is passed as a timeout to init, we will log a warning.
     private static final int EXCESSIVE_INIT_WAIT_SECONDS = 15;
 
+    // Shared by both registration paths, so that a plugin failing during init and the same plugin
+    // failing under registerPlugin are reported identically.
+    private static final String PLUGIN_GET_HOOKS_ERROR =
+            "Exception thrown getting hooks for plugin {}. Unable to get hooks, plugin will not be registered.";
+    private static final String PLUGIN_REGISTER_ERROR = "Exception thrown registering plugin {}.";
+    private static final String PLUGIN_ON_PLUGINS_READY_ERROR =
+            "Exception thrown executing onPluginsReady for plugin {}.";
+
 
     /**
      * Initializes the singleton/primary instance. The result is a {@link Future} which
@@ -229,7 +237,7 @@ public class LDClient implements LDClientInterface, Closeable {
                         instance.hookRunner.addHook(hook);
                     }
                 } catch (Exception e) {
-                    logger.error("Exception thrown getting hooks for plugin " + plugin.getMetadata().getName() + ". Unable to get hooks, plugin will not be registered.");
+                    logger.error(PLUGIN_GET_HOOKS_ERROR, pluginName(plugin));
                 }
             }
 
@@ -238,8 +246,8 @@ public class LDClient implements LDClientInterface, Closeable {
                 try {
                     plugin.register(instance, metadata);
                 } catch (Exception e) {
-                    pluginFailures.add(new RegistrationCompleteResult.Failure.PluginFailure(plugin.getMetadata().getName(), e.getMessage(), e));
-                    logger.error("Exception thrown registering plugin " + plugin.getMetadata().getName() + ".");
+                    pluginFailures.add(new RegistrationCompleteResult.Failure.PluginFailure(pluginName(plugin), e.getMessage(), e));
+                    logger.error(PLUGIN_REGISTER_ERROR, pluginName(plugin));
                 }
             }
 
@@ -247,13 +255,7 @@ public class LDClient implements LDClientInterface, Closeable {
                     ? RegistrationCompleteResult.success()
                     : RegistrationCompleteResult.failure(pluginFailures);
 
-            for (Plugin plugin : instance.plugins) {
-                try {
-                    plugin.onPluginsReady(pluginsRegistrationResult, metadata);
-                } catch (Exception e) {
-                    logger.error("Exception thrown executing onPluginsReady for plugin " + plugin.getMetadata().getName() + ".");
-                }
-            }
+            notifyPluginsReady(instance, metadata, pluginsRegistrationResult, logger);
         }
 
         final AtomicInteger initCounter = new AtomicInteger(config.getMobileKeys().size());
@@ -909,32 +911,41 @@ public class LDClient implements LDClientInterface, Closeable {
         try {
             pluginHooks = plugin.getHooks(metadata);
         } catch (Exception e) {
-            logger.error("Exception thrown getting hooks for plugin " + pluginName(plugin) + ". Unable to get hooks, plugin will not be registered.");
+            logger.error(PLUGIN_GET_HOOKS_ERROR, pluginName(plugin));
             return;
         }
 
-        RegistrationCompleteResult result;
         try {
             plugin.register(this, metadata);
-            result = RegistrationCompleteResult.success();
-        } catch (Exception e) {
-            logger.error("Exception thrown registering plugin " + pluginName(plugin) + ".");
-            result = RegistrationCompleteResult.failure(Collections.singletonList(
-                    new RegistrationCompleteResult.Failure.PluginFailure(pluginName(plugin), e.getMessage(), e)));
-        }
-
-        // The hooks go live only once register has succeeded, so a plugin whose registration failed
-        // never contributes hooks, and a plugin's own hooks do not observe its register call.
-        if (result instanceof RegistrationCompleteResult.Success) {
+            // Adding the hooks only after register returns keeps them from observing the register
+            // call itself, and leaves a plugin whose registration threw contributing none.
             for (Hook hook : pluginHooks) {
                 hookRunner.addHook(hook);
             }
-        }
-
-        try {
-            plugin.onPluginsReady(result, metadata);
         } catch (Exception e) {
-            logger.error("Exception thrown executing onPluginsReady for plugin " + pluginName(plugin) + ".");
+            logger.error(PLUGIN_REGISTER_ERROR, pluginName(plugin));
+        }
+    }
+
+    /**
+     * Tells every plugin configured on the environment how registering that whole batch went.
+     *
+     * <p>Kept in one place so that the SDK's only remaining call to the deprecated
+     * {@link Plugin#onPluginsReady} can be removed along with it.
+     */
+    @SuppressWarnings("deprecation")
+    private static void notifyPluginsReady(
+            LDClient instance,
+            EnvironmentMetadata metadata,
+            RegistrationCompleteResult result,
+            LDLogger logger
+    ) {
+        for (Plugin plugin : instance.plugins) {
+            try {
+                plugin.onPluginsReady(result, metadata);
+            } catch (Exception e) {
+                logger.error(PLUGIN_ON_PLUGINS_READY_ERROR, pluginName(plugin));
+            }
         }
     }
 
@@ -942,7 +953,7 @@ public class LDClient implements LDClientInterface, Closeable {
      * Reads a plugin's name for a log message, tolerating a plugin whose metadata itself throws:
      * otherwise reporting one failure would raise another out of the handler that reports it.
      */
-    private String pluginName(Plugin plugin) {
+    private static String pluginName(Plugin plugin) {
         try {
             return plugin.getMetadata().getName();
         } catch (Exception e) {

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
@@ -408,10 +408,11 @@ public interface LDClientInterface extends Closeable {
      * Registers a single {@link Plugin} with this client after it has been created; to register
      * plugins beforehand, use the {@code plugins} method of {@link LDConfig.Builder} instead.
      * <p>
-     * The plugin's hooks only start running once {@link Plugin#register} returns, so they do not
-     * observe what {@code register} itself does. Exceptions from {@link Plugin#getHooks} or
-     * {@code register} are logged rather than propagated, and leave the plugin contributing no
-     * hooks. Registration covers this client, and so this environment, alone.
+     * The plugin's hooks start running before {@link Plugin#register} is called, as they do for a
+     * plugin configured up front, so they observe what {@code register} itself does. An exception
+     * from {@link Plugin#getHooks} is logged and leaves the plugin unregistered and contributing no
+     * hooks; one from {@code register} is logged but leaves the hooks in place. Neither propagates.
+     * Registration covers this client, and so this environment, alone.
      * {@link Plugin#onPluginsReady} is not called, because it reports on a batch of plugins
      * registered together.
      *

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
@@ -412,6 +412,8 @@ public interface LDClientInterface extends Closeable {
      * observe what {@code register} itself does. Exceptions from {@link Plugin#getHooks} or
      * {@code register} are logged rather than propagated, and leave the plugin contributing no
      * hooks. Registration covers this client, and so this environment, alone.
+     * {@link Plugin#onPluginsReady} is not called, because it reports on a batch of plugins
+     * registered together.
      *
      * @param plugin the plugin to register; must not be null
      */

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
@@ -408,11 +408,11 @@ public interface LDClientInterface extends Closeable {
      * Registers a single {@link Plugin} with this client after it has been created; to register
      * plugins beforehand, use the {@code plugins} method of {@link LDConfig.Builder} instead.
      * <p>
-     * The plugin's hooks only start running once {@link Plugin#register} has returned, as they do
-     * for a plugin configured up front, so they do not observe what {@code register} itself does.
-     * Exceptions from {@link Plugin#getHooks} or {@code register} are logged rather than propagated,
-     * and leave the plugin contributing no hooks. Registration covers this client, and so this
-     * environment, alone.
+     * The plugin's hooks start running before {@link Plugin#register} is called, as they do for a
+     * plugin configured up front, so they observe what {@code register} itself does. Exceptions from
+     * {@link Plugin#getHooks} or {@code register} are logged rather than propagated; one from
+     * {@code getHooks} leaves the plugin contributing no hooks and unregistered. Registration covers
+     * this client, and so this environment, alone.
      * {@link Plugin#onPluginsReady} is not called, because it reports on a batch of plugins
      * registered together.
      *

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
@@ -408,11 +408,11 @@ public interface LDClientInterface extends Closeable {
      * Registers a single {@link Plugin} with this client after it has been created; to register
      * plugins beforehand, use the {@code plugins} method of {@link LDConfig.Builder} instead.
      * <p>
-     * The plugin's hooks start running before {@link Plugin#register} is called, as they do for a
-     * plugin configured up front, so they observe what {@code register} itself does. An exception
-     * from {@link Plugin#getHooks} is logged and leaves the plugin unregistered and contributing no
-     * hooks; one from {@code register} is logged but leaves the hooks in place. Neither propagates.
-     * Registration covers this client, and so this environment, alone.
+     * The plugin's hooks only start running once {@link Plugin#register} has returned, as they do
+     * for a plugin configured up front, so they do not observe what {@code register} itself does.
+     * Exceptions from {@link Plugin#getHooks} or {@code register} are logged rather than propagated,
+     * and leave the plugin contributing no hooks. Registration covers this client, and so this
+     * environment, alone.
      * {@link Plugin#onPluginsReady} is not called, because it reports on a batch of plugins
      * registered together.
      *

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/LDClientInterface.java
@@ -6,6 +6,7 @@ import com.launchdarkly.sdk.EvaluationDetail;
 import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.LDValue;
 import com.launchdarkly.sdk.android.integrations.Hook;
+import com.launchdarkly.sdk.android.integrations.Plugin;
 
 import java.io.Closeable;
 import java.util.Map;
@@ -402,4 +403,17 @@ public interface LDClientInterface extends Closeable {
      * @param hook The hook to add.
      */
     void addHook(Hook hook);
+
+    /**
+     * Registers a single {@link Plugin} with this client after it has been created; to register
+     * plugins beforehand, use the {@code plugins} method of {@link LDConfig.Builder} instead.
+     * <p>
+     * The plugin's hooks only start running once {@link Plugin#register} returns, so they do not
+     * observe what {@code register} itself does. Exceptions from {@link Plugin#getHooks} or
+     * {@code register} are logged rather than propagated, and leave the plugin contributing no
+     * hooks. Registration covers this client, and so this environment, alone.
+     *
+     * @param plugin the plugin to register; must not be null
+     */
+    void registerPlugin(Plugin plugin);
 }

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/integrations/Plugin.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/integrations/Plugin.java
@@ -54,10 +54,8 @@ public abstract class Plugin {
      *
      * @param result   the outcome of registering that batch of plugins
      * @param metadata metadata about the environment where the plugin is running.
-     * @deprecated This reports on a batch of plugins registered together, so it has no meaning for
-     *             {@link LDClient#registerPlugin(Plugin)}, which registers a single plugin and does
-     *             not call it. Do work that needs the client in {@link #register} instead, which
-     *             both paths call.
+     * @deprecated onPluginsReady was necessary in the past, 
+     * but has since been determined to be problematic and is being removed in the next major version.
      */
     @Deprecated
     public void onPluginsReady(RegistrationCompleteResult result, EnvironmentMetadata metadata) {

--- a/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/integrations/Plugin.java
+++ b/launchdarkly-android-client-sdk/src/main/java/com/launchdarkly/sdk/android/integrations/Plugin.java
@@ -48,6 +48,18 @@ public abstract class Plugin {
         return Collections.emptyList();
     }
 
+    /**
+     * Called once every plugin configured on {@link com.launchdarkly.sdk.android.LDConfig} has been
+     * registered, reporting whether they all succeeded.
+     *
+     * @param result   the outcome of registering that batch of plugins
+     * @param metadata metadata about the environment where the plugin is running.
+     * @deprecated This reports on a batch of plugins registered together, so it has no meaning for
+     *             {@link LDClient#registerPlugin(Plugin)}, which registers a single plugin and does
+     *             not call it. Do work that needs the client in {@link #register} instead, which
+     *             both paths call.
+     */
+    @Deprecated
     public void onPluginsReady(RegistrationCompleteResult result, EnvironmentMetadata metadata) {
         // default: do nothing
     }

--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/HookRunnerTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/HookRunnerTest.java
@@ -593,6 +593,48 @@ public class HookRunnerTest extends EasyMockSupport {
     }
 
     @Test
+    public void addsAGroupOfHooksAllAtOnce() throws InterruptedException {
+        int groupSize = 8;
+        int groups = 300;
+        HookRunner runner = new HookRunner(logging.logger, Collections.emptyList());
+        AtomicInteger hooksObserved = new AtomicInteger();
+        List<Integer> partialGroups = new ArrayList<>();
+
+        Thread adder = new Thread(() -> {
+            for (int i = 0; i < groups; i++) {
+                List<Hook> group = new ArrayList<>(groupSize);
+                for (int j = 0; j < groupSize; j++) {
+                    group.add(new Hook("group-hook") {
+                        @Override
+                        public Map<String, Object> beforeEvaluation(EvaluationSeriesContext seriesContext, Map<String, Object> seriesData) {
+                            hooksObserved.incrementAndGet();
+                            return seriesData;
+                        }
+                    });
+                }
+                runner.addHooks(group);
+            }
+        });
+
+        EvaluationDetail<LDValue> evaluationResult = EvaluationDetail.fromValue(LDValue.of(true), 1, EvaluationReason.off());
+        adder.start();
+        while (adder.isAlive()) {
+            hooksObserved.set(0);
+            runner.withEvaluation("testMethod", "test-flag", LDContext.create("user-123"), LDValue.of(false), () -> evaluationResult);
+            int observed = hooksObserved.get();
+            if (observed % groupSize != 0) {
+                partialGroups.add(observed);
+            }
+        }
+        adder.join();
+
+        // A group of hooks becomes visible in one step, so an evaluation racing the registration runs either
+        // all of a group's hooks or none of them, never part of one.
+        assertEquals(Collections.emptyList(), partialGroups);
+        logging.assertNothingLogged();
+    }
+
+    @Test
     public void logsUnknownHookWhenGetMetadataThrows() {
         String method = "testMethod";
         String key = "test-flag";


### PR DESCRIPTION
## Summary

Plugins could only be supplied through `LDConfig`, so an integration that learns about a plugin later — or that wants to instrument a client it did not configure — had no way in. This adds `LDClient.registerPlugin(Plugin)`, mirroring the method the .NET and Flutter SDKs already expose.

- **Hooks go live only once `register` succeeds.** This follows the .NET ordering, and it differs from configuration-time registration, where a plugin's hooks are active before `register` is called. The consequence is that a plugin whose registration failed never contributes hooks, and a plugin's own hooks do not observe the evaluations or identify calls its `register` makes.
- **`EnvironmentMetadata` is now retained on the instance** rather than living in a local map during `init`, so a plugin registered later is handed the same environment description as one configured up front. The `init` loop switches from a `Map<LDClient, EnvironmentMetadata>` to a `List<LDClient>` accordingly.
- **Failures are contained.** A throwing `getHooks` leaves the plugin unregistered; a throwing `register` yields a failure result passed to `onPluginsReady`. Neither propagates to the caller. Reading the plugin's name for the log message tolerates metadata that itself throws, so reporting one failure cannot raise another out of the handler reporting it.

Registration applies to the one client it is called on, so a multi-environment setup means calling it per environment.

## Test plan

Eight cases added to `LDClientPluginsTest`, all passing on an API 36 emulator alongside the three pre-existing plugin tests (11 total):

- [x] `registerPluginPassesClientAndEnvironmentMetadata`
- [x] `registerPluginActivatesBundledHooks`
- [x] `registerPluginDoesNotRunTheRegisteringPluginsOwnHooks`
- [x] `registerPluginReportsSuccessToOnPluginsReady`
- [x] `registerPluginDoesNotRegisterPluginWhoseGetHooksThrows`
- [x] `registerPluginToleratesRegisterThrowing`
- [x] `registerPluginRejectsNullPlugin`
- [x] `registerPluginAppliesOnlyToTheClientItIsCalledOn`
- [x] `testDebugUnitTest` green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds **`LDClient.registerPlugin(Plugin)`** on `LDClientInterface` so integrations can attach plugins after init, aligned with other LaunchDarkly mobile SDKs. **`EnvironmentMetadata` is stored on each client** (replacing the init-only map) so late registration gets the same environment description as config-time plugins.
> 
> Plugin setup is **centralized in `registerPlugins`**, used from both init and `registerPlugin`: collect hooks via `getHooks`, **activate all hooks in one `HookRunner.addHooks` step**, then call `register`. Hooks are live **before** `register` runs (including work done inside `register`); a throwing `register` is logged and does not remove already-active hooks. `getHooks` failures skip registration; other plugins still register. **`registerPlugin` does not invoke `onPluginsReady`** (batch-only); init still notifies via `notifyPluginsReady`. **`Plugin.onPluginsReady` is deprecated** in Javadoc.
> 
> **`HookRunner`** gains batch `addHooks` (with `addHook` delegating to it) so a plugin’s hook set cannot be half-visible to concurrent evaluations. Tests cover runtime registration, multi-environment scoping, failure modes, and config-time behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e234d5f02ff433956e1c778a64a81fa7fda275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->