### PR TITLE
fix: make the close/reset timer tests deterministic

### DIFF
--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/StateDebounceManagerTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/StateDebounceManagerTest.java
@@ -144,15 +144,20 @@ public class StateDebounceManagerTest {
     }
 
     @Test
-    public void closeCancelsPendingTimer() throws InterruptedException {
+    public void closeCancelsPendingTimer() {
+        // Manually-driven executor for the same reason as resetCancelsPendingTimer: the pre-close
+        // sleep can overshoot the debounce window on a loaded runner, letting the timer fire before
+        // close() has a chance to cancel it.
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr = new StateDebounceManager(
+                true, true, manualExecutor, TEST_DEBOUNCE_MS, callCount::incrementAndGet);
 
         mgr.setNetworkAvailable(false);
-        Thread.sleep(TEST_DEBOUNCE_MS / 3);
         mgr.close();
+        assertEquals("close should cancel the scheduled timer", 1, manualExecutor.cancelledCount());
 
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals("pending timer should be cancelled on close", 0, callCount.get());
     }
 
@@ -341,15 +346,23 @@ public class StateDebounceManagerTest {
     // ==== reset() (CONNMODE 3.5.6 — identify bypasses debounce) ====
 
     @Test
-    public void resetCancelsPendingTimer() throws InterruptedException {
+    public void resetCancelsPendingTimer() {
+        // Uses a manually-driven executor instead of Thread.sleep so the test is deterministic:
+        // the short pre-reset sleep can overshoot the debounce window on a loaded runner, and once
+        // the timer has begun firing reset() cannot recall it -- reset() re-seeds the baseline
+        // under taskLock while fireIfChanged() reads it under workLock, an interleaving the
+        // implementation documents as harmless but which this assertion cannot tolerate.
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr = new StateDebounceManager(
+                true, true, manualExecutor, TEST_DEBOUNCE_MS, callCount::incrementAndGet);
 
         mgr.setNetworkAvailable(false);
-        Thread.sleep(TEST_DEBOUNCE_MS / 3);
         mgr.reset(true, true);
+        assertEquals("reset should cancel the scheduled timer", 1, manualExecutor.cancelledCount());
 
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        // Draining the queue runs nothing, because the only scheduled task was cancelled.
+        manualExecutor.runPendingTasks();
         assertEquals("reset should cancel the pending timer", 0, callCount.get());
 
         mgr.close();


### PR DESCRIPTION
closeCancelsPendingTimer and resetCancelsPendingTimer slept for a fraction of the debounce window and then asserted the timer never fired. On a loaded runner that sleep can overshoot the window, and once the timer has begun firing neither close() nor reset() can recall it, so the tests failed for reasons unrelated to the behaviour they cover.

Both now drive a ManualTaskExecutor instead of sleeping, asserting that the scheduled task was cancelled and that draining the queue runs nothing.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Provide links to any issues in this repository or elsewhere relating to this pull request.

**Describe the solution you've provided**

Provide a clear and concise description of what you expect to happen.

**Describe alternatives you've considered**

Provide a clear and concise description of any alternative solutions or features you've considered.

**Additional context**

Add any other context about the pull request here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Makes `closeCancelsPendingTimer` and `resetCancelsPendingTimer` deterministic by driving a `ManualTaskExecutor` instead of sleeping a fraction of the debounce window.
> 
> Those sleeps could overshoot on a loaded runner, so the timer fired before `close()`/`reset()` could cancel it. The tests now assert the scheduled task was cancelled and that draining the queue runs nothing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0160533a7fa985ccf36caf84fcee9ebed85d344d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->