### PR TITLE
test: make the remaining StateDebounceManager tests deterministic

### DIFF
--- a/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/StateDebounceManagerTest.java
+++ b/launchdarkly-android-client-sdk/src/test/java/com/launchdarkly/sdk/android/StateDebounceManagerTest.java
@@ -13,6 +13,27 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Tests for {@link StateDebounceManager}.
+ * <p>
+ * Tests here use one of two task executors, and the choice is deliberate:
+ * <ul>
+ *   <li>{@link ManualTaskExecutor} for everything asserting debounce <em>semantics</em>
+ *       (coalescing, A&rarr;B&rarr;A dedup, close, reset). A scheduled task runs only when the
+ *       test calls {@link ManualTaskExecutor#runPendingTasks()}, so each such call stands in for
+ *       "the debounce window elapsed". This makes the test single-threaded and removes both
+ *       timing races that {@code Thread.sleep} introduces: the timer thread never has to be
+ *       scheduled within a wall-clock budget, and a sequence of setters can never be split
+ *       across two debounce windows by an unlucky pause.</li>
+ *   <li>{@link SimpleTestTaskExecutor} (a real single-thread scheduled pool) only where the
+ *       real-time or cross-thread behavior <em>is</em> the thing under test:
+ *       {@link #callbackFiredAfterDebounceWindow()} and
+ *       {@link #closeWaitsForInflightReconcileCallback()}. Both use latches with generous
+ *       timeouts rather than fixed sleeps.</li>
+ * </ul>
+ * Immediate-mode tests ({@code debounceMs == 0}) touch no executor at all -- the callback fires
+ * synchronously inside the setter -- so they are deterministic either way.
+ */
 public class StateDebounceManagerTest {
 
     private static final long TEST_DEBOUNCE_MS = 50;
@@ -39,6 +60,22 @@ public class StateDebounceManagerTest {
         );
     }
 
+    /**
+     * Builds a manager driven by a caller-supplied {@link ManualTaskExecutor} so the test decides
+     * when the debounce window elapses. See the class Javadoc for why this is preferred.
+     */
+    private StateDebounceManager createManager(
+            ManualTaskExecutor manualExecutor,
+            boolean networkAvailable,
+            boolean foreground,
+            Runnable onReconcile
+    ) {
+        return new StateDebounceManager(
+                networkAvailable, foreground,
+                manualExecutor, TEST_DEBOUNCE_MS, onReconcile
+        );
+    }
+
     @Test
     public void callbackFiredAfterDebounceWindow() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
@@ -53,13 +90,10 @@ public class StateDebounceManagerTest {
 
     @Test
     public void callbackNotFiredBeforeDebounceWindow() {
-        // Uses a manually-driven executor instead of Thread.sleep so the test is deterministic:
-        // a wall-clock "should not have fired yet" assertion is flaky on loaded CI runners, where
-        // the short pre-window sleep can overshoot the debounce window and let the timer fire.
         AtomicInteger callCount = new AtomicInteger(0);
         ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
-        StateDebounceManager mgr = new StateDebounceManager(
-                true, true, manualExecutor, TEST_DEBOUNCE_MS, callCount::incrementAndGet);
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         // The state change schedules the debounce timer but must not fire the callback yet.
         mgr.setNetworkAvailable(false);
@@ -73,14 +107,18 @@ public class StateDebounceManagerTest {
     }
 
     @Test
-    public void duplicateValueIsNoOp() throws InterruptedException {
+    public void duplicateValueIsNoOp() {
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
+        // Both setters write the value the manager already holds, so neither should schedule
+        // a timer; draining the queue therefore has nothing to run.
         mgr.setNetworkAvailable(true);
         mgr.setForeground(true);
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
 
+        manualExecutor.runPendingTasks();
         assertEquals("no-op changes should not trigger callback", 0, callCount.get());
 
         mgr.close();
@@ -88,13 +126,10 @@ public class StateDebounceManagerTest {
 
     @Test
     public void timerResetsOnEachEvent() {
-        // Uses a manually-driven executor instead of Thread.sleep so the test is deterministic:
-        // wall-clock-based timing made the mid-window "should not have fired yet" assertion flaky
-        // on loaded CI runners (the cumulative sleeps could overshoot the debounce window).
         AtomicInteger callCount = new AtomicInteger(0);
         ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
-        StateDebounceManager mgr = new StateDebounceManager(
-                true, true, manualExecutor, TEST_DEBOUNCE_MS, callCount::incrementAndGet);
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         // First event schedules a timer; it has not fired yet.
         mgr.setNetworkAvailable(false);
@@ -113,9 +148,11 @@ public class StateDebounceManagerTest {
     }
 
     @Test
-    public void multipleRapidChangesCoalesceIntoOneCallback() throws InterruptedException {
+    public void multipleRapidChangesCoalesceIntoOneCallback() {
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         mgr.setNetworkAvailable(false);
         mgr.setNetworkAvailable(true);
@@ -123,7 +160,12 @@ public class StateDebounceManagerTest {
         mgr.setForeground(false);
         mgr.setForeground(true);
 
-        Thread.sleep(TEST_DEBOUNCE_MS * 4);
+        // All five changes land in one window: each reschedules, cancelling the timer its
+        // predecessor scheduled, so only the last one survives to run.
+        assertEquals("every change after the first should reschedule",
+                4, manualExecutor.cancelledCount());
+
+        manualExecutor.runPendingTasks();
         // Final state (network=false, foreground=true) differs from initial baseline
         // (network=true, foreground=true), so the dedup allows the callback to fire.
         assertEquals("rapid changes should coalesce into one callback", 1, callCount.get());
@@ -132,26 +174,25 @@ public class StateDebounceManagerTest {
     }
 
     @Test
-    public void closePreventsFutureCallbacks() throws InterruptedException {
+    public void closePreventsFutureCallbacks() {
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         mgr.setNetworkAvailable(false);
         mgr.close();
 
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals("callback should not fire after close()", 0, callCount.get());
     }
 
     @Test
     public void closeCancelsPendingTimer() {
-        // Manually-driven executor for the same reason as resetCancelsPendingTimer: the pre-close
-        // sleep can overshoot the debounce window on a loaded runner, letting the timer fire before
-        // close() has a chance to cancel it.
         AtomicInteger callCount = new AtomicInteger(0);
         ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
-        StateDebounceManager mgr = new StateDebounceManager(
-                true, true, manualExecutor, TEST_DEBOUNCE_MS, callCount::incrementAndGet);
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         mgr.setNetworkAvailable(false);
         mgr.close();
@@ -162,15 +203,17 @@ public class StateDebounceManagerTest {
     }
 
     @Test
-    public void settersAfterCloseDoNotTriggerCallback() throws InterruptedException {
+    public void settersAfterCloseDoNotTriggerCallback() {
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         mgr.close();
         mgr.setNetworkAvailable(false);
         mgr.setForeground(false);
 
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals("setters after close should not trigger callback", 0, callCount.get());
     }
 
@@ -270,16 +313,20 @@ public class StateDebounceManagerTest {
     }
 
     @Test
-    public void separateEventsProduceSeparateCallbacks() throws InterruptedException {
+    public void separateEventsProduceSeparateCallbacks() {
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
+        // Each runPendingTasks() closes one debounce window, so these are two distinct windows
+        // rather than two changes coalescing into one.
         mgr.setNetworkAvailable(false);
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals(1, callCount.get());
 
         mgr.setNetworkAvailable(true);
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals(2, callCount.get());
 
         mgr.close();
@@ -292,24 +339,29 @@ public class StateDebounceManagerTest {
     // debounce window and returned to the baseline state.
 
     @Test
-    public void dedupSuppressesAtoBtoAWithinWindow() throws InterruptedException {
+    public void dedupSuppressesAtoBtoAWithinWindow() {
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
-        // foreground: true → false → true within the same window
+        // foreground: true → false → true. Both setters are guaranteed to land in the same
+        // window, because no timer can fire until runPendingTasks() below.
         mgr.setForeground(false);
         mgr.setForeground(true);
 
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals("A→B→A within window should suppress the callback", 0, callCount.get());
 
         mgr.close();
     }
 
     @Test
-    public void dedupSuppressesMultiAxisAtoBtoAWithinWindow() throws InterruptedException {
+    public void dedupSuppressesMultiAxisAtoBtoAWithinWindow() {
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         // Both axes oscillate and return to their baseline within the window.
         mgr.setNetworkAvailable(false);
@@ -317,7 +369,7 @@ public class StateDebounceManagerTest {
         mgr.setNetworkAvailable(true);
         mgr.setForeground(true);
 
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals("multi-axis A→B→A within window should suppress the callback",
                 0, callCount.get());
 
@@ -325,19 +377,21 @@ public class StateDebounceManagerTest {
     }
 
     @Test
-    public void dedupAllowsGenuineChangeAfterSuppression() throws InterruptedException {
+    public void dedupAllowsGenuineChangeAfterSuppression() {
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         // First window: A→B→A, suppressed.
         mgr.setForeground(false);
         mgr.setForeground(true);
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals("first window should be suppressed", 0, callCount.get());
 
         // Second window: a genuine transition still fires.
         mgr.setForeground(false);
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals("subsequent genuine transition should fire", 1, callCount.get());
 
         mgr.close();
@@ -347,15 +401,15 @@ public class StateDebounceManagerTest {
 
     @Test
     public void resetCancelsPendingTimer() {
-        // Uses a manually-driven executor instead of Thread.sleep so the test is deterministic:
-        // the short pre-reset sleep can overshoot the debounce window on a loaded runner, and once
-        // the timer has begun firing reset() cannot recall it -- reset() re-seeds the baseline
-        // under taskLock while fireIfChanged() reads it under workLock, an interleaving the
-        // implementation documents as harmless but which this assertion cannot tolerate.
+        // Driving the timer manually also sidesteps an interleaving this assertion cannot
+        // tolerate: once the timer has begun firing, reset() cannot recall it, because reset()
+        // re-seeds the baseline under taskLock while fireIfChanged() reads it under workLock.
+        // The implementation documents that interleaving as harmless, but it is not observable
+        // as "cancelled" from the test's point of view.
         AtomicInteger callCount = new AtomicInteger(0);
         ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
-        StateDebounceManager mgr = new StateDebounceManager(
-                true, true, manualExecutor, TEST_DEBOUNCE_MS, callCount::incrementAndGet);
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         mgr.setNetworkAvailable(false);
         mgr.reset(true, true);
@@ -369,56 +423,63 @@ public class StateDebounceManagerTest {
     }
 
     @Test
-    public void resetDoesNotInvokeReconcileCallback() throws InterruptedException {
+    public void resetDoesNotInvokeReconcileCallback() {
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         // Drive a state transition through to a successful fire.
         mgr.setNetworkAvailable(false);
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals(1, callCount.get());
 
-        // Reset should NOT invoke the callback even though it changes the seed.
+        // Reset should NOT invoke the callback even though it changes the seed, and it should
+        // leave nothing behind for a later window to run.
         mgr.reset(true, true);
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals("reset itself should not fire onReconcile", 1, callCount.get());
 
         mgr.close();
     }
 
     @Test
-    public void resetReseedsBaselineForNewWindow() throws InterruptedException {
+    public void resetReseedsBaselineForNewWindow() {
         // After reset, the A→B→C→A baseline must match the new seed values, so the
         // first genuine change relative to the new seed produces a fire.
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         // Re-seed to (false, false). lastApplied also becomes (false, false).
         mgr.reset(false, false);
 
         // setNetworkAvailable(true): differs from new baseline → schedule + fire.
         mgr.setNetworkAvailable(true);
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals("change relative to reset seed should fire", 1, callCount.get());
 
         mgr.close();
     }
 
     @Test
-    public void resetClearsAtoBtoABaseline() throws InterruptedException {
+    public void resetClearsAtoBtoABaseline() {
         // Without reset(), setForeground(true)→false→true within a single window is
         // dedup'd (raw state returned to baseline). After reset, the same sequence
         // measured from the NEW baseline should also be dedup'd — i.e. reset re-anchors
         // the baseline to its argument, not to the previous fire.
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         mgr.reset(false, true);
 
         // From baseline (false, true): toggle network true→false→true within window.
         mgr.setNetworkAvailable(true);
         mgr.setNetworkAvailable(false);
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals("A→B→A relative to reset baseline should also be suppressed",
                 0, callCount.get());
 
@@ -426,16 +487,18 @@ public class StateDebounceManagerTest {
     }
 
     @Test
-    public void resetAfterCloseIsNoOp() throws InterruptedException {
+    public void resetAfterCloseIsNoOp() {
         AtomicInteger callCount = new AtomicInteger(0);
-        StateDebounceManager mgr = createManager(true, true, callCount::incrementAndGet);
+        ManualTaskExecutor manualExecutor = new ManualTaskExecutor();
+        StateDebounceManager mgr =
+                createManager(manualExecutor, true, true, callCount::incrementAndGet);
 
         mgr.close();
         mgr.reset(false, false);
 
         // Subsequent setX must not produce a fire (manager remains closed).
         mgr.setNetworkAvailable(true);
-        Thread.sleep(TEST_DEBOUNCE_MS * 3);
+        manualExecutor.runPendingTasks();
         assertEquals("reset on a closed manager must not resurrect it", 0, callCount.get());
     }
 


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

Test-only change; no production code is touched.

**Related issues**

SDK-3006

**Describe the solution you've provided**

`StateDebounceManagerTest` is the largest single source of flaky CI failures in this repo. Mining every failed `ci.yml` run with retained logs (2026-06-01 to 2026-08-25, all 27 of them) turned up 15 failures caused by flaky unit tests, and 7 of those were this one class across 5 different methods and 5 unrelated branches. Each failure was exactly 1 failed test out of ~730, and each was verified unrelated to its PR's diff — the clearest example being a PR that changed only `build.gradle` and still failed a debounce assertion. Six of the 15 landed directly on pushes to `main`.

Root cause: the tests infer the state of an asynchronous scheduler from wall-clock `Thread.sleep` on the test thread. With `TEST_DEBOUNCE_MS = 50` and sleeps of 3–4x the window, the margin is ~100ms, inside normal jitter for a loaded 2-core runner executing the whole suite in one JVM. That yields two races pulling in opposite directions:

- **Under-run** ("should have fired") — the executor thread may not get scheduled inside the sleep budget.
- **Setup overshoot** ("should not have fired") — consecutive setters must all land in one 50ms window. A pause between them expires window 1, the timer fires with intermediate state, and a suppression assertion sees 1 instead of 0. The race is in the setup, not the wait.

Because they pull opposite ways, fixing one method just relocates the failure. That is the actual history here: three reactive determinism commits (2026-06-01, 2026-06-03, and PR 394 on 2026-08-18), each converting whichever method had most recently flaked.

This change finishes the job. The 12 timing-agnostic tests move to `ManualTaskExecutor`, where a scheduled task runs only when the test drains the queue — so each drain stands in for the debounce window elapsing, and both races become impossible by construction. All 15 `Thread.sleep` calls in those tests are gone.

The strongest evidence this is the right remedy: **no method has ever failed after being converted.** `callbackNotFiredBeforeDebounceWindow` failed Jun 2 and Jun 3, was converted Jun 3, and has been silent since. `resetCancelsPendingTimer` failed Aug 18 at 14:13Z (its conversion landed Aug 19 at 05:29Z) and again Aug 21 on a branch that does not contain that conversion commit.

Two tests deliberately keep the real executor, because a manual executor would delete what they test:

- `callbackFiredAfterDebounceWindow` — the only end-to-end coverage that a real `scheduleTask(delayMillis)` actually fires.
- `closeWaitsForInflightReconcileCallback` — the `close()` drain barrier, which needs a callback genuinely in flight on another thread.

Both already use latches with generous timeouts rather than fixed sleeps, and neither has ever flaked. The four immediate-mode tests (`debounceMs == 0`) are untouched: they bypass the executor entirely and fire synchronously inside the setter.

Breakdown of all 22 methods:

| Group | Count | Action |
| --- | --- | --- |
| Sleep-based, timing-agnostic | 12 | Converted (3 had flaked, 9 were latent) |
| Already converted | 4 | Construction unified onto the new helper |
| Immediate mode | 4 | None |
| Genuinely timing / cross-thread | 2 | Keep real executor by design |

**Describe alternatives you've considered**

- *Raising `TEST_DEBOUNCE_MS` or the sleep multipliers* — makes under-run rarer but stays probabilistic, does nothing structural for the setup race, and adds ~20s to the suite.
- *Injecting a `Clock` and keeping a real executor* — the flakiness is thread *scheduling*, not time *reading*; you would still be waiting on another thread.
- *Await-based assertions everywhere* — good for "should have fired" (and is what the two retained tests already do), but you cannot await a non-event, so it cannot fix the suppression assertions.
- *Converting all 22 to be deterministic* — rejected. It would trade flakiness for a coverage hole, since `StateDebounceManager`'s documented `taskLock`/`workLock` contract and `close()` drain barrier would then go entirely unexercised.

**Additional context**

Verification: the class passes 22/22; run 20 times consecutively it was clean 20/20; the full `testDebugUnitTest` suite is 730 tests, 0 failures. Note that the local repeat loop only proves no *new* nondeterminism was introduced — the original failures were CI-load-dependent and would not reproduce on an idle dev machine either. The real argument is structural, and real confirmation is the absence of recurrence in CI.

Reviewer notes on scope, both called out deliberately:

1. The four already-converted tests are touched, to point them at the new `createManager(ManualTaskExecutor, ...)` overload. Leaving 4 tests inlining the constructor while 12 use a helper seemed worse than a slightly wider diff.
2. The repeated per-method "why a manual executor" comments are consolidated into class Javadoc rather than duplicated 16 times. The method-specific part of `resetCancelsPendingTimer`'s comment (the `taskLock`/`workLock` interleaving note) is retained.

One assertion was strengthened: `multipleRapidChangesCoalesceIntoOneCallback` now also asserts `cancelledCount() == 4`, proving the five changes genuinely coalesced rather than merely yielding one callback. This mirrors the existing pattern in `timerResetsOnEachEvent`.

Known follow-ups, not in scope:

- `ManualTaskExecutor` discards `delayMillis` and `runPendingTasks()` flushes the whole queue, so after this change `debounceMs` is only exercised end-to-end by one test. A virtual clock (`advanceTimeBy`) would make window-boundary assertions meaningful rather than near-vacuous.
- `ManualTaskExecutor` is not thread-safe (plain `ArrayList`, non-volatile fields). Correct today because it is single-threaded by construction, but worth a class-level warning before anyone extends it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Eliminates CI flakiness in `StateDebounceManagerTest`** by replacing wall-clock `Thread.sleep` with explicit `ManualTaskExecutor#runPendingTasks()` in the 12 debounce-semantics tests, so each drain simulates the debounce window without scheduler races.
> 
> Adds class Javadoc and a `createManager(ManualTaskExecutor, …)` helper, routes those tests through it (including ones already on a manual executor), drops `throws InterruptedException` where sleeps are gone, and tightens `multipleRapidChangesCoalesceIntoOneCallback` with a `cancelledCount() == 4` check. **`callbackFiredAfterDebounceWindow`** and **`closeWaitsForInflightReconcileCallback`** still use `SimpleTestTaskExecutor` for real timing/cross-thread behavior; immediate-mode tests are unchanged.
> 
> No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc839b0330da77a069cc0683bdd74a3f80119bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->